### PR TITLE
Replace UI and internal Giphy references

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -15,7 +15,6 @@ repositories {
     google()
     jcenter()
     maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
-    maven { url "https://giphy.bintray.com/giphy-sdk" }
     maven { url "https://www.jitpack.io" }
 }
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -518,7 +518,7 @@
             android:label=""
             android:theme="@style/Calypso.NoActionBar" />
         <activity
-            android:name=".ui.giphy.GiphyPickerActivity"
+            android:name=".ui.gif.GifPickerActivity"
             android:theme="@style/Calypso.NoActionBar" />
 
         <!-- Notifications activities -->

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -40,7 +40,7 @@ import org.wordpress.android.ui.comments.EditCommentActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationDetailsFragment;
 import org.wordpress.android.ui.domains.DomainSuggestionsFragment;
-import org.wordpress.android.ui.giphy.GiphyPickerActivity;
+import org.wordpress.android.ui.gif.GifPickerActivity;
 import org.wordpress.android.ui.history.HistoryAdapter;
 import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
 import org.wordpress.android.ui.main.AddContentAdapter;
@@ -438,7 +438,7 @@ public interface AppComponent extends AndroidInjector<WordPress> {
 
     void inject(JetpackRemoteInstallFragment jetpackRemoteInstallFragment);
 
-    void inject(GiphyPickerActivity object);
+    void inject(GifPickerActivity object);
 
     void inject(PlansListAdapter object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -33,8 +33,8 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWi
 import org.wordpress.android.ui.stats.refresh.lists.widget.minified.StatsMinifiedWidgetConfigureFragment;
 import org.wordpress.android.util.wizard.WizardManager;
 import org.wordpress.android.viewmodel.ContextProvider;
-import org.wordpress.android.viewmodel.giphy.provider.GifProvider;
-import org.wordpress.android.viewmodel.giphy.provider.TenorProvider;
+import org.wordpress.android.viewmodel.gif.provider.GifProvider;
+import org.wordpress.android.viewmodel.gif.provider.TenorProvider;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -37,7 +37,7 @@ import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel;
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel;
 import org.wordpress.android.viewmodel.domains.DomainRegistrationDetailsViewModel;
 import org.wordpress.android.viewmodel.domains.DomainSuggestionsViewModel;
-import org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel;
+import org.wordpress.android.viewmodel.gif.GifPickerViewModel;
 import org.wordpress.android.viewmodel.history.HistoryViewModel;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
 import org.wordpress.android.viewmodel.pages.PageListViewModel;
@@ -218,8 +218,8 @@ abstract class ViewModelModule {
 
     @Binds
     @IntoMap
-    @ViewModelKey(GiphyPickerViewModel.class)
-    abstract ViewModel giphyPickerViewModel(GiphyPickerViewModel viewModel);
+    @ViewModelKey(GifPickerViewModel.class)
+    abstract ViewModel gifPickerViewModel(GifPickerViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -37,7 +37,7 @@ import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.comments.CommentsActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity;
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose;
-import org.wordpress.android.ui.giphy.GiphyPickerActivity;
+import org.wordpress.android.ui.gif.GifPickerActivity;
 import org.wordpress.android.ui.history.HistoryDetailActivity;
 import org.wordpress.android.ui.history.HistoryDetailContainerFragment;
 import org.wordpress.android.ui.history.HistoryListItem.Revision;
@@ -175,7 +175,7 @@ public class ActivityLauncher {
         properties.put("from", activity.getClass().getSimpleName());
         AnalyticsTracker.track(Stat.GIF_PICKER_ACCESSED, properties);
 
-        Intent intent = new Intent(activity, GiphyPickerActivity.class);
+        Intent intent = new Intent(activity, GifPickerActivity.class);
         intent.putExtra(WordPress.SITE, site);
         activity.startActivityForResult(intent, requestCode);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifMediaViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifMediaViewHolder.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.giphy
+package org.wordpress.android.ui.gif
 
 import android.view.LayoutInflater
 import android.view.View
@@ -17,7 +17,7 @@ import org.wordpress.android.util.redirectContextClickToLongPressListener
 import org.wordpress.android.viewmodel.gif.GifMediaViewModel
 
 /**
- * Represents a single item in the [GiphyPickerActivity]'s grid (RecyclerView).
+ * Represents a single item in the [GifPickerActivity]'s grid (RecyclerView).
  *
  * This is meant to show a single animated gif.
  *
@@ -25,7 +25,7 @@ import org.wordpress.android.viewmodel.gif.GifMediaViewModel
  * behavior is handled by the [GiphyPickerViewModel]. This is designed this way so that [GiphyPickerViewModel]
  * encapsulates all the logic of managing selected items as well as keeping their selection numbers continuous.
  */
-class GiphyMediaViewHolder(
+class GifMediaViewHolder(
     /**
      * The [ImageManager] to use for loading an image in to the ImageView
      */
@@ -76,7 +76,7 @@ class GiphyMediaViewHolder(
      *
      * The [mediaViewModel] is optional because we enable placeholders in the paged list created by
      * [org.wordpress.android.viewmodel.gif.GifPickerViewModel]. This causes null values to be bound to
-     * [GiphyMediaViewHolder] instances.
+     * [GifMediaViewHolder] instances.
      */
     override fun bind(item: GifMediaViewModel?) {
         super.bind(item)
@@ -137,7 +137,7 @@ class GiphyMediaViewHolder(
         private const val THUMBNAIL_SCALE_SELECTED: Float = 0.8f
 
         /**
-         * Create the layout and a new instance of [GiphyMediaViewHolder]
+         * Create the layout and a new instance of [GifMediaViewHolder]
          */
         fun create(
             imageManager: ImageManager,
@@ -145,11 +145,11 @@ class GiphyMediaViewHolder(
             onLongClickListener: (GifMediaViewModel) -> Unit,
             parent: ViewGroup,
             thumbnailViewDimensions: ThumbnailViewDimensions
-        ): GiphyMediaViewHolder {
+        ): GifMediaViewHolder {
             // We are intentionally reusing this layout since the UI is very similar.
             val view = LayoutInflater.from(parent.context)
                     .inflate(R.layout.media_picker_thumbnail, parent, false)
-            return GiphyMediaViewHolder(
+            return GifMediaViewHolder(
                     imageManager = imageManager,
                     onClickListener = onClickListener,
                     onLongClickListener = onLongClickListener,

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifMediaViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifMediaViewHolder.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.viewmodel.gif.GifMediaViewModel
  * This is meant to show a single animated gif.
  *
  * This ViewHolder references a readonly [GifMediaViewModel]. It should never update the [GifMediaViewModel]. That
- * behavior is handled by the [GiphyPickerViewModel]. This is designed this way so that [GiphyPickerViewModel]
+ * behavior is handled by the [GifPickerViewModel]. This is designed this way so that [GifPickerViewModel]
  * encapsulates all the logic of managing selected items as well as keeping their selection numbers continuous.
  */
 class GifMediaViewHolder(

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
@@ -36,9 +36,7 @@ import org.wordpress.android.viewmodel.gif.GifPickerViewModel.State
 import javax.inject.Inject
 
 /**
- * Allows searching of gifs from Giphy
- *
- * Important: Giphy is currently disabled everywhere. We are planning to replace it with a different service provider.
+ * Allows searching of gifs from a giving provider
  */
 class GifPickerActivity : AppCompatActivity() {
     /**
@@ -126,7 +124,7 @@ class GifPickerActivity : AppCompatActivity() {
      * Configure the search view to execute search when the keyboard's Done button is pressed.
      */
     private fun initializeSearchView() {
-        search_view.queryHint = getString(R.string.giphy_picker_search_hint)
+        search_view.queryHint = getString(R.string.gif_picker_search_hint)
 
         search_view.setOnQueryTextListener(object : OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
@@ -203,7 +201,7 @@ class GifPickerActivity : AppCompatActivity() {
         emptyView.run {
             image.setImageResource(R.drawable.img_illustration_media_105dp)
             bottomImage.setImageResource(R.drawable.img_tenor_100dp)
-            bottomImage.contentDescription = getString(R.string.giphy_powered_by_giphy)
+            bottomImage.contentDescription = getString(R.string.gif_powered_by_tenor)
         }
 
         viewModel.emptyDisplayMode.getDistinct().observe(this, Observer { emptyDisplayMode ->
@@ -216,7 +214,7 @@ class GifPickerActivity : AppCompatActivity() {
                         updateLayoutForSearch(isSearching = true, topMargin = 0)
 
                         visibility = View.VISIBLE
-                        title.setText(R.string.giphy_picker_empty_search_list)
+                        title.setText(R.string.gif_picker_empty_search_list)
                         image.visibility = View.GONE
                         bottomImage.visibility = View.GONE
                     }
@@ -226,7 +224,7 @@ class GifPickerActivity : AppCompatActivity() {
                         updateLayoutForSearch(isSearching = false, topMargin = 0)
 
                         visibility = View.VISIBLE
-                        title.setText(R.string.giphy_picker_initial_empty_text)
+                        title.setText(R.string.gif_picker_initial_empty_text)
                         image.visibility = View.VISIBLE
                         bottomImage.visibility = View.VISIBLE
                     }
@@ -254,7 +252,7 @@ class GifPickerActivity : AppCompatActivity() {
 
             ToastUtils.showToast(
                     this@GifPickerActivity,
-                    R.string.giphy_picker_endless_scroll_network_error,
+                    R.string.gif_picker_endless_scroll_network_error,
                     ToastUtils.Duration.LONG
             )
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerActivity.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.giphy
+package org.wordpress.android.ui.gif
 
 import android.app.Activity
 import android.content.Intent
@@ -20,7 +20,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActionableEmptyView
-import org.wordpress.android.ui.giphy.GiphyMediaViewHolder.ThumbnailViewDimensions
+import org.wordpress.android.ui.gif.GifMediaViewHolder.ThumbnailViewDimensions
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.util.AniUtils
 import org.wordpress.android.util.DisplayUtils
@@ -40,9 +40,9 @@ import javax.inject.Inject
  *
  * Important: Giphy is currently disabled everywhere. We are planning to replace it with a different service provider.
  */
-class GiphyPickerActivity : AppCompatActivity() {
+class GifPickerActivity : AppCompatActivity() {
     /**
-     * Used for loading images in [GiphyMediaViewHolder]
+     * Used for loading images in [GifMediaViewHolder]
      */
     @Inject lateinit var imageManager: ImageManager
     @Inject lateinit var viewModelFactory: ViewModelFactory
@@ -53,7 +53,7 @@ class GiphyPickerActivity : AppCompatActivity() {
     private val gridColumnCount: Int by lazy { if (DisplayUtils.isLandscape(this)) 4 else 3 }
 
     /**
-     * Passed to the [GiphyMediaViewHolder] which will be used as its dimensions
+     * Passed to the [GifMediaViewHolder] which will be used as its dimensions
      */
     private val thumbnailViewDimensions: ThumbnailViewDimensions by lazy {
         val width = DisplayUtils.getDisplayPixelWidth(this) / gridColumnCount
@@ -93,10 +93,10 @@ class GiphyPickerActivity : AppCompatActivity() {
     }
 
     /**
-     * Configure the RecyclerView to use [GiphyPickerPagedListAdapter] and display the items in a grid
+     * Configure the RecyclerView to use [GifPickerPagedListAdapter] and display the items in a grid
      */
     private fun initializeRecyclerView() {
-        val pagedListAdapter = GiphyPickerPagedListAdapter(
+        val pagedListAdapter = GifPickerPagedListAdapter(
                 imageManager = imageManager,
                 thumbnailViewDimensions = thumbnailViewDimensions,
                 onMediaViewClickListener = { mediaViewModel ->
@@ -112,7 +112,7 @@ class GiphyPickerActivity : AppCompatActivity() {
         )
 
         recycler.apply {
-            layoutManager = GridLayoutManager(this@GiphyPickerActivity, gridColumnCount)
+            layoutManager = GridLayoutManager(this@GifPickerActivity, gridColumnCount)
             adapter = pagedListAdapter
         }
 
@@ -253,7 +253,7 @@ class GiphyPickerActivity : AppCompatActivity() {
             event ?: return@Observer
 
             ToastUtils.showToast(
-                    this@GiphyPickerActivity,
+                    this@GifPickerActivity,
                     R.string.giphy_picker_endless_scroll_network_error,
                     ToastUtils.Duration.LONG
             )
@@ -301,7 +301,7 @@ class GiphyPickerActivity : AppCompatActivity() {
                 finish()
             } else if (result?.errorMessageStringResId != null) {
                 ToastUtils.showToast(
-                        this@GiphyPickerActivity,
+                        this@GifPickerActivity,
                         result.errorMessageStringResId,
                         ToastUtils.Duration.SHORT
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerPagedListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerPagedListAdapter.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.gif.GifMediaViewModel
 
 /**
- * An [RecyclerView] adapter to be used with the [PagedList] created by [GiphyPickerViewModel]
+ * An [RecyclerView] adapter to be used with the [PagedList] created by [GifPickerViewModel]
  */
 class GifPickerPagedListAdapter(
     private val imageManager: ImageManager,
@@ -39,7 +39,7 @@ class GifPickerPagedListAdapter(
             /**
              * Always assume that two similar [GifMediaViewModel] objects always have the same content.
              *
-             * It is probably extremely unlikely that GIFs from Giphy will change while the user is performing
+             * It is probably extremely unlikely that GIFs will change while the user is performing
              * a search.
              */
             override fun areContentsTheSame(oldItem: GifMediaViewModel, newItem: GifMediaViewModel): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerPagedListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/GifPickerPagedListAdapter.kt
@@ -1,23 +1,23 @@
-package org.wordpress.android.ui.giphy
+package org.wordpress.android.ui.gif
 
 import android.view.ViewGroup
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil.ItemCallback
-import org.wordpress.android.ui.giphy.GiphyMediaViewHolder.ThumbnailViewDimensions
+import org.wordpress.android.ui.gif.GifMediaViewHolder.ThumbnailViewDimensions
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.gif.GifMediaViewModel
 
 /**
  * An [RecyclerView] adapter to be used with the [PagedList] created by [GiphyPickerViewModel]
  */
-class GiphyPickerPagedListAdapter(
+class GifPickerPagedListAdapter(
     private val imageManager: ImageManager,
     private val thumbnailViewDimensions: ThumbnailViewDimensions,
     private val onMediaViewClickListener: (GifMediaViewModel?) -> Unit,
     private val onMediaViewLongClickListener: (GifMediaViewModel) -> Unit
-) : PagedListAdapter<GifMediaViewModel, GiphyMediaViewHolder>(DIFF_CALLBACK) {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GiphyMediaViewHolder {
-        return GiphyMediaViewHolder.create(
+) : PagedListAdapter<GifMediaViewModel, GifMediaViewHolder>(DIFF_CALLBACK) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GifMediaViewHolder {
+        return GifMediaViewHolder.create(
                 imageManager = imageManager,
                 onClickListener = onMediaViewClickListener,
                 onLongClickListener = onMediaViewLongClickListener,
@@ -26,7 +26,7 @@ class GiphyPickerPagedListAdapter(
         )
     }
 
-    override fun onBindViewHolder(holder: GiphyMediaViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: GifMediaViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/gif/LifecycleOwnerViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/gif/LifecycleOwnerViewHolder.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.giphy
+package org.wordpress.android.ui.gif
 
 import android.view.View
 import android.view.View.OnAttachStateChangeListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/giphy/GiphyMediaViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/giphy/GiphyMediaViewHolder.kt
@@ -14,14 +14,14 @@ import org.wordpress.android.util.getDistinct
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.PHOTO
 import org.wordpress.android.util.redirectContextClickToLongPressListener
-import org.wordpress.android.viewmodel.giphy.GiphyMediaViewModel
+import org.wordpress.android.viewmodel.gif.GifMediaViewModel
 
 /**
  * Represents a single item in the [GiphyPickerActivity]'s grid (RecyclerView).
  *
  * This is meant to show a single animated gif.
  *
- * This ViewHolder references a readonly [GiphyMediaViewModel]. It should never update the [GiphyMediaViewModel]. That
+ * This ViewHolder references a readonly [GifMediaViewModel]. It should never update the [GifMediaViewModel]. That
  * behavior is handled by the [GiphyPickerViewModel]. This is designed this way so that [GiphyPickerViewModel]
  * encapsulates all the logic of managing selected items as well as keeping their selection numbers continuous.
  */
@@ -35,11 +35,11 @@ class GiphyMediaViewHolder(
      *
      * If there is no bound [mediaViewModel], this can mean that there was an API error or this is just a placeholder.
      */
-    private val onClickListener: (GiphyMediaViewModel?) -> Unit,
+    private val onClickListener: (GifMediaViewModel?) -> Unit,
     /**
      * A function that is called when the user performs a long press on the thumbnail
      */
-    private val onLongClickListener: (GiphyMediaViewModel) -> Unit,
+    private val onLongClickListener: (GifMediaViewModel) -> Unit,
     /**
      * The view used for this `ViewHolder`.
      */
@@ -48,13 +48,13 @@ class GiphyMediaViewHolder(
      * The dimensions used for the ImageView
      */
     thumbnailViewDimensions: ThumbnailViewDimensions
-) : LifecycleOwnerViewHolder<GiphyMediaViewModel>(itemView) {
+) : LifecycleOwnerViewHolder<GifMediaViewModel>(itemView) {
     data class ThumbnailViewDimensions(val width: Int, val height: Int)
 
     private val thumbnailView: ImageView = itemView.image_thumbnail
     private val selectionNumberTextView: TextView = itemView.text_selection_count
 
-    private var mediaViewModel: GiphyMediaViewModel? = null
+    private var mediaViewModel: GifMediaViewModel? = null
 
     init {
         thumbnailView.apply {
@@ -72,13 +72,13 @@ class GiphyMediaViewHolder(
     }
 
     /**
-     * Update the views to use the given [GiphyMediaViewModel]
+     * Update the views to use the given [GifMediaViewModel]
      *
      * The [mediaViewModel] is optional because we enable placeholders in the paged list created by
-     * [org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel]. This causes null values to be bound to
+     * [org.wordpress.android.viewmodel.gif.GifPickerViewModel]. This causes null values to be bound to
      * [GiphyMediaViewHolder] instances.
      */
-    override fun bind(item: GiphyMediaViewModel?) {
+    override fun bind(item: GifMediaViewModel?) {
         super.bind(item)
 
         this.mediaViewModel = item
@@ -141,8 +141,8 @@ class GiphyMediaViewHolder(
          */
         fun create(
             imageManager: ImageManager,
-            onClickListener: (GiphyMediaViewModel?) -> Unit,
-            onLongClickListener: (GiphyMediaViewModel) -> Unit,
+            onClickListener: (GifMediaViewModel?) -> Unit,
+            onLongClickListener: (GifMediaViewModel) -> Unit,
             parent: ViewGroup,
             thumbnailViewDimensions: ThumbnailViewDimensions
         ): GiphyMediaViewHolder {

--- a/WordPress/src/main/java/org/wordpress/android/ui/giphy/GiphyPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/giphy/GiphyPickerActivity.kt
@@ -29,10 +29,10 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.getDistinct
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.ViewModelFactory
-import org.wordpress.android.viewmodel.giphy.GiphyMediaViewModel
-import org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel
-import org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel.EmptyDisplayMode
-import org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel.State
+import org.wordpress.android.viewmodel.gif.GifMediaViewModel
+import org.wordpress.android.viewmodel.gif.GifPickerViewModel
+import org.wordpress.android.viewmodel.gif.GifPickerViewModel.EmptyDisplayMode
+import org.wordpress.android.viewmodel.gif.GifPickerViewModel.State
 import javax.inject.Inject
 
 /**
@@ -48,7 +48,7 @@ class GiphyPickerActivity : AppCompatActivity() {
     @Inject lateinit var viewModelFactory: ViewModelFactory
     @Inject lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
 
-    private lateinit var viewModel: GiphyPickerViewModel
+    private lateinit var viewModel: GifPickerViewModel
 
     private val gridColumnCount: Int by lazy { if (DisplayUtils.isLandscape(this)) 4 else 3 }
 
@@ -66,7 +66,7 @@ class GiphyPickerActivity : AppCompatActivity() {
 
         val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
 
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(GiphyPickerViewModel::class.java)
+        viewModel = ViewModelProviders.of(this, viewModelFactory).get(GifPickerViewModel::class.java)
         viewModel.setup(site)
 
         // We are intentionally reusing this layout since the UI is very similar.
@@ -152,7 +152,7 @@ class GiphyPickerActivity : AppCompatActivity() {
     }
 
     /**
-     * Configure the selection bar and its labels when the [GiphyPickerViewModel] selected items change
+     * Configure the selection bar and its labels when the [GifPickerViewModel] selected items change
      */
     private fun initializeSelectionBar() {
         viewModel.selectionBarIsVisible.observe(this, Observer {
@@ -277,7 +277,7 @@ class GiphyPickerActivity : AppCompatActivity() {
      *
      * @param mediaViewModels A non-empty list
      */
-    private fun showPreview(mediaViewModels: List<GiphyMediaViewModel>) {
+    private fun showPreview(mediaViewModels: List<GifMediaViewModel>) {
         check(mediaViewModels.isNotEmpty())
 
         val uris = mediaViewModels.map { it.previewImageUri.toString() }
@@ -310,7 +310,7 @@ class GiphyPickerActivity : AppCompatActivity() {
     }
 
     /**
-     * Set up enabling/disabling of controls depending on the current [GiphyPickerViewModel.State]:
+     * Set up enabling/disabling of controls depending on the current [GifPickerViewModel.State]:
      *
      * - [State.IDLE]: All normal functions are allowed
      * - [State.DOWNLOADING] or [State.FINISHED]: "Add", "Preview", searching, and selecting are disabled

--- a/WordPress/src/main/java/org/wordpress/android/ui/giphy/GiphyPickerPagedListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/giphy/GiphyPickerPagedListAdapter.kt
@@ -5,7 +5,7 @@ import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil.ItemCallback
 import org.wordpress.android.ui.giphy.GiphyMediaViewHolder.ThumbnailViewDimensions
 import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.viewmodel.giphy.GiphyMediaViewModel
+import org.wordpress.android.viewmodel.gif.GifMediaViewModel
 
 /**
  * An [RecyclerView] adapter to be used with the [PagedList] created by [GiphyPickerViewModel]
@@ -13,9 +13,9 @@ import org.wordpress.android.viewmodel.giphy.GiphyMediaViewModel
 class GiphyPickerPagedListAdapter(
     private val imageManager: ImageManager,
     private val thumbnailViewDimensions: ThumbnailViewDimensions,
-    private val onMediaViewClickListener: (GiphyMediaViewModel?) -> Unit,
-    private val onMediaViewLongClickListener: (GiphyMediaViewModel) -> Unit
-) : PagedListAdapter<GiphyMediaViewModel, GiphyMediaViewHolder>(DIFF_CALLBACK) {
+    private val onMediaViewClickListener: (GifMediaViewModel?) -> Unit,
+    private val onMediaViewLongClickListener: (GifMediaViewModel) -> Unit
+) : PagedListAdapter<GifMediaViewModel, GiphyMediaViewHolder>(DIFF_CALLBACK) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GiphyMediaViewHolder {
         return GiphyMediaViewHolder.create(
                 imageManager = imageManager,
@@ -31,18 +31,18 @@ class GiphyPickerPagedListAdapter(
     }
 
     companion object {
-        private val DIFF_CALLBACK = object : ItemCallback<GiphyMediaViewModel>() {
-            override fun areItemsTheSame(oldItem: GiphyMediaViewModel, newItem: GiphyMediaViewModel): Boolean {
+        private val DIFF_CALLBACK = object : ItemCallback<GifMediaViewModel>() {
+            override fun areItemsTheSame(oldItem: GifMediaViewModel, newItem: GifMediaViewModel): Boolean {
                 return oldItem.id == newItem.id
             }
 
             /**
-             * Always assume that two similar [GiphyMediaViewModel] objects always have the same content.
+             * Always assume that two similar [GifMediaViewModel] objects always have the same content.
              *
              * It is probably extremely unlikely that GIFs from Giphy will change while the user is performing
              * a search.
              */
-            override fun areContentsTheSame(oldItem: GiphyMediaViewModel, newItem: GiphyMediaViewModel): Boolean {
+            override fun areContentsTheSame(oldItem: GifMediaViewModel, newItem: GifMediaViewModel): Boolean {
                 return true
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -64,7 +64,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.giphy.GiphyPickerActivity;
+import org.wordpress.android.ui.gif.GifPickerActivity;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaFilter;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaGridListener;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
@@ -485,8 +485,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 break;
             case RequestCodes.GIF_PICKER:
                 if (resultCode == RESULT_OK
-                    && data.hasExtra(GiphyPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)) {
-                    int[] mediaLocalIds = data.getIntArrayExtra(GiphyPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS);
+                    && data.hasExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)) {
+                    int[] mediaLocalIds = data.getIntArrayExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS);
 
                     ArrayList<MediaModel> mediaModels = new ArrayList<>();
                     for (int localId : mediaLocalIds) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2232,7 +2232,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 case RequestCodes.GIF_PICKER:
                     if (data.hasExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)) {
                         int[] localIds = data.getIntArrayExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS);
-                        mEditorMedia.addMediaFromGiphyToPostAsync(localIds);
+                        mEditorMedia.addGifMediaToPostAsync(localIds);
                     }
                     break;
                 case RequestCodes.HISTORY_DETAIL:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -99,7 +99,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.PagePostCreationSourcesDetail;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.Shortcut;
-import org.wordpress.android.ui.giphy.GiphyPickerActivity;
+import org.wordpress.android.ui.gif.GifPickerActivity;
 import org.wordpress.android.ui.history.HistoryListItem.Revision;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
@@ -2230,8 +2230,8 @@ public class EditPostActivity extends AppCompatActivity implements
                     }
                     break;
                 case RequestCodes.GIF_PICKER:
-                    if (data.hasExtra(GiphyPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)) {
-                        int[] localIds = data.getIntArrayExtra(GiphyPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS);
+                    if (data.hasExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS)) {
+                        int[] localIds = data.getIntArrayExtra(GifPickerActivity.KEY_SAVED_MEDIA_MODEL_LOCAL_IDS);
                         mEditorMedia.addMediaFromGiphyToPostAsync(localIds);
                     }
                     break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -138,7 +138,7 @@ class EditorMedia @Inject constructor(
     /**
      * This won't create a MediaModel. It assumes the model was already created.
      */
-    fun addMediaFromGiphyToPostAsync(localMediaIds: IntArray) {
+    fun addGifMediaToPostAsync(localMediaIds: IntArray) {
         launch {
             addLocalMediaToPostUseCase.addLocalMediaToEditorAsync(
                     localMediaIds.toList(),

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/CoroutineScopedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/CoroutineScopedViewModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.CoroutineScope

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaFetcher.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import android.content.Context
 import android.webkit.MimeTypeMap
@@ -18,13 +18,13 @@ import org.wordpress.android.util.WPMediaUtils
 import javax.inject.Inject
 
 /**
- * Downloads [GiphyMediaViewModel.largeImageUri] objects and saves them as [MediaModel]
+ * Downloads [GifMediaViewModel.largeImageUri] objects and saves them as [MediaModel]
  *
  * The download happens concurrently and primarily uses [Dispatchers.IO]. This means that we are limited by the number
  * of threads backed by that `CoroutineDispatcher`. In the future, we should probably add a limit to the number of
  * GIFs that users can select to reduce the likelihood of OOM exceptions.
  */
-class GiphyMediaFetcher @Inject constructor(
+class GifMediaFetcher @Inject constructor(
     private val context: Context,
     private val mediaStore: MediaStore,
     private val dispatcher: Dispatcher
@@ -38,22 +38,22 @@ class GiphyMediaFetcher @Inject constructor(
      */
     @Throws
     suspend fun fetchAndSave(
-        giphyMediaViewModels: List<GiphyMediaViewModel>,
+        gifMediaViewModels: List<GifMediaViewModel>,
         site: SiteModel
     ): List<MediaModel> = coroutineScope {
         // Execute [fetchAndSave] for all giphyMediaViewModels first so that they are queued and executed in the
         // background. We'll call `await()` once they are queued.
-        return@coroutineScope giphyMediaViewModels.map {
-            fetchAndSave(scope = this, giphyMediaViewModel = it, site = site)
+        return@coroutineScope gifMediaViewModels.map {
+            fetchAndSave(scope = this, gifMediaViewModel = it, site = site)
         }.map { it.await() }
     }
 
     private fun fetchAndSave(
         scope: CoroutineScope,
-        giphyMediaViewModel: GiphyMediaViewModel,
+        gifMediaViewModel: GifMediaViewModel,
         site: SiteModel
     ): Deferred<MediaModel> = scope.async(Dispatchers.IO) {
-        val uri = giphyMediaViewModel.largeImageUri
+        val uri = gifMediaViewModel.largeImageUri
         // No need to log the Exception here. The underlying method that is used, [MediaUtils.downloadExternalMedia]
         // already logs any errors.
         val downloadedUri = WPMediaUtils.fetchMedia(context, uri) ?: throw Exception("Failed to download the image.")
@@ -65,7 +65,7 @@ class GiphyMediaFetcher @Inject constructor(
         val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension)
 
         val mediaModel = FluxCUtils.mediaModelFromLocalUri(context, downloadedUri, mimeType, mediaStore, site.id)
-        mediaModel.title = giphyMediaViewModel.title
+        mediaModel.title = gifMediaViewModel.title
         dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel))
 
         return@async mediaModel

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaFetcher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaFetcher.kt
@@ -41,7 +41,7 @@ class GifMediaFetcher @Inject constructor(
         gifMediaViewModels: List<GifMediaViewModel>,
         site: SiteModel
     ): List<MediaModel> = coroutineScope {
-        // Execute [fetchAndSave] for all giphyMediaViewModels first so that they are queued and executed in the
+        // Execute [fetchAndSave] for all gifMediaViewModels first so that they are queued and executed in the
         // background. We'll call `await()` once they are queued.
         return@coroutineScope gifMediaViewModels.map {
             fetchAndSave(scope = this, gifMediaViewModel = it, site = site)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaViewModel.kt
@@ -4,20 +4,16 @@ import android.net.Uri
 import androidx.lifecycle.LiveData
 
 /**
- * A data-representation of [GiphyMediaViewHolder]
+ * A data-representation of [GifMediaViewHolder]
  *
- * The values of this class comes from Giphy's [Media] model. The [Media] object is big so we use this class to
- * only keep a minimal amount of memory. This also hides the complexity of navigating the values of [Media].
+ * The values of this class comes from [GifProvider] as a list.
  *
- * This class also houses the selection status. The [GiphyMediaViewHolder] observes the [isSelected] and
+ * This class also houses the selection status. The [GifMediaViewHolder] observes the [isSelected] and
  * [selectionNumber] properties to update itself.
- *
- * See the [Giphy API docs](https://developers.giphy.com/docs/) for more information on what a [Media] object contains.
- * Search for "The GIF Object" section.
  */
 interface GifMediaViewModel {
     /**
-     * The id from Giphy's [Media]
+     * The id from GIF [Media]
      */
     val id: String
     /**
@@ -37,7 +33,7 @@ interface GifMediaViewModel {
      */
     val largeImageUri: Uri
     /**
-     * The title that appears on giphy.com
+     * The title that appears on the GIF
      */
     val title: String
     /**

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaViewModel.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.LiveData
  */
 interface GifMediaViewModel {
     /**
-     * The id from GIF [Media]
+     * The GIF unique id
      */
     val id: String
     /**

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifMediaViewModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import android.net.Uri
 import androidx.lifecycle.LiveData
@@ -15,7 +15,7 @@ import androidx.lifecycle.LiveData
  * See the [Giphy API docs](https://developers.giphy.com/docs/) for more information on what a [Media] object contains.
  * Search for "The GIF Object" section.
  */
-interface GiphyMediaViewModel {
+interface GifMediaViewModel {
     /**
      * The id from Giphy's [Media]
      */

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerDataSource.kt
@@ -1,33 +1,33 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.paging.PositionalDataSource
-import org.wordpress.android.viewmodel.giphy.provider.GifProvider
+import org.wordpress.android.viewmodel.gif.provider.GifProvider
 
 /**
- * The PagedListDataSource that is created and managed by [GiphyPickerDataSourceFactory]
+ * The PagedListDataSource that is created and managed by [GifPickerDataSourceFactory]
  *
  * This performs paged API requests using the [apiClient]. A new instance of this class must be created if the
  * [searchQuery] is changed by the user.
  */
-class GiphyPickerDataSource(
+class GifPickerDataSource(
     private val gifProvider: GifProvider,
     private val searchQuery: String
-) : PositionalDataSource<GiphyMediaViewModel>() {
+) : PositionalDataSource<GifMediaViewModel>() {
     /**
      * The data structure used for storing failed [loadRange] calls so they can be retried later.
      */
     private data class RangeLoadArguments(
         val params: LoadRangeParams,
-        val callback: LoadRangeCallback<GiphyMediaViewModel>
+        val callback: LoadRangeCallback<GifMediaViewModel>
     )
 
     /**
      * The error received when [loadInitial] fails.
      *
      * Unlike [rangeLoadErrorEvent], this is not a [LiveData] because the consumer of this method
-     * [GiphyPickerViewModel] simply uses it to check for null values and reacts to a different event.
+     * [GifPickerViewModel] simply uses it to check for null values and reacts to a different event.
      *
      * This is cleared when [loadInitial] is started.
      */
@@ -53,15 +53,15 @@ class GiphyPickerDataSource(
     /**
      * Always the load the first page (startingPosition = 0) from the Giphy API
      *
-     * The [GiphyPickerDataSourceFactory] recreates [GiphyPickerDataSource] instances whenever a new [searchQuery]
+     * The [GifPickerDataSourceFactory] recreates [GifPickerDataSource] instances whenever a new [searchQuery]
      * is queued. The [LoadInitialParams.requestedStartPosition] may have a value that is only valid for the
      * previous [searchQuery]. If that value is greater than the total search results of the new [searchQuery],
      * a crash will happen.
      *
-     * Using `0` as the `startPosition` forces the [GiphyPickerDataSource] consumer to reset the list (UI) from the
+     * Using `0` as the `startPosition` forces the [GifPickerDataSource] consumer to reset the list (UI) from the
      * top.
      */
-    override fun loadInitial(params: LoadInitialParams, callback: LoadInitialCallback<GiphyMediaViewModel>) {
+    override fun loadInitial(params: LoadInitialParams, callback: LoadInitialCallback<GifMediaViewModel>) {
         val startPosition = 0
 
         initialLoadError = null
@@ -81,7 +81,7 @@ class GiphyPickerDataSource(
      */
     private fun requestInitialSearch(
         params: LoadInitialParams,
-        callback: LoadInitialCallback<GiphyMediaViewModel>
+        callback: LoadInitialCallback<GifMediaViewModel>
     ) {
         val startPosition = 0
         gifProvider.search(searchQuery, startPosition, params.requestedLoadSize,
@@ -107,7 +107,7 @@ class GiphyPickerDataSource(
      * Errors are dispatched to [rangeLoadErrorEvent]. If successful, previously failed calls of this method are
      * automatically retried using [retryAllFailedRangeLoads].
      */
-    override fun loadRange(params: LoadRangeParams, callback: LoadRangeCallback<GiphyMediaViewModel>) {
+    override fun loadRange(params: LoadRangeParams, callback: LoadRangeCallback<GifMediaViewModel>) {
         gifProvider.search(searchQuery, params.startPosition, params.loadSize,
                 onSuccess = { gifs, _ ->
                     callback.onResult(gifs)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerDataSource.kt
@@ -51,7 +51,7 @@ class GifPickerDataSource(
     private val failedRangeLoadArguments = mutableListOf<RangeLoadArguments>()
 
     /**
-     * Always the load the first page (startingPosition = 0) from the Giphy API
+     * Always the load the first page (startingPosition = 0) from the Gif API
      *
      * The [GifPickerDataSourceFactory] recreates [GifPickerDataSource] instances whenever a new [searchQuery]
      * is queued. The [LoadInitialParams.requestedStartPosition] may have a value that is only valid for the
@@ -102,7 +102,7 @@ class GifPickerDataSource(
     }
 
     /**
-     * Load a given range of items ([params]) from the Giphy API.
+     * Load a given range of items ([params]) from the Gif API.
      *
      * Errors are dispatched to [rangeLoadErrorEvent]. If successful, previously failed calls of this method are
      * automatically retried using [retryAllFailedRangeLoads].

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceFactory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceFactory.kt
@@ -1,27 +1,27 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.paging.DataSource
 import androidx.paging.DataSource.Factory
-import org.wordpress.android.viewmodel.giphy.provider.GifProvider
+import org.wordpress.android.viewmodel.gif.provider.GifProvider
 import javax.inject.Inject
 
 /**
- * Creates instances of [GiphyPickerDataSource]
+ * Creates instances of [GifPickerDataSource]
  *
  * Whenever the [searchQuery] is changed:
  *
- * 1. The last [GiphyPickerDataSource] is invalidated
- * 2. The [LivePagedListBuilder] will create a new [GiphyPickerDataSource] by calling [create]
- * 3. The new [GiphyPickerDataSource] will start another paged API request
+ * 1. The last [GifPickerDataSource] is invalidated
+ * 2. The [LivePagedListBuilder] will create a new [GifPickerDataSource] by calling [create]
+ * 3. The new [GifPickerDataSource] will start another paged API request
  */
-class GiphyPickerDataSourceFactory @Inject constructor(private val gifProvider: GifProvider) : Factory<Int, GiphyMediaViewModel>() {
+class GifPickerDataSourceFactory @Inject constructor(private val gifProvider: GifProvider) : Factory<Int, GifMediaViewModel>() {
     /**
      * The active search query.
      *
-     * When changed, the current [GiphyPickerDataSource] will be invalidated. A new API search will be performed.
+     * When changed, the current [GifPickerDataSource] will be invalidated. A new API search will be performed.
      */
     var searchQuery: String = ""
         set(value) {
@@ -34,26 +34,26 @@ class GiphyPickerDataSourceFactory @Inject constructor(private val gifProvider: 
      *
      * We retain this so we can invalidate it later when [searchQuery] is changed.
      */
-    private val dataSource = MutableLiveData<GiphyPickerDataSource>()
+    private val dataSource = MutableLiveData<GifPickerDataSource>()
 
     /**
-     * The [GiphyPickerDataSource.initialLoadError] of the current [dataSource]
+     * The [GifPickerDataSource.initialLoadError] of the current [dataSource]
      */
     val initialLoadError: Throwable? get() = dataSource.value?.initialLoadError
     /**
-     * The [GiphyPickerDataSource.rangeLoadErrorEvent] of the current [dataSource]
+     * The [GifPickerDataSource.rangeLoadErrorEvent] of the current [dataSource]
      */
     val rangeLoadErrorEvent: LiveData<Throwable> = Transformations.switchMap(dataSource) { it.rangeLoadErrorEvent }
 
     /**
      * Retries all previously failed page loads.
      *
-     * @see [GiphyPickerDataSource.retryAllFailedRangeLoads]
+     * @see [GifPickerDataSource.retryAllFailedRangeLoads]
      */
     fun retryAllFailedRangeLoads() = dataSource.value?.retryAllFailedRangeLoads()
 
-    override fun create(): DataSource<Int, GiphyMediaViewModel> {
-        val dataSource = GiphyPickerDataSource(gifProvider, searchQuery)
+    override fun create(): DataSource<Int, GifMediaViewModel> {
+        val dataSource = GifPickerDataSource(gifProvider, searchQuery)
         this.dataSource.postValue(dataSource)
         return dataSource
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerViewModel.kt
@@ -269,8 +269,8 @@ class GifPickerViewModel @Inject constructor(
         _state.postValue(State.DOWNLOADING)
 
         val result = try {
-            val giphyMediaViewModels = _selectedMediaViewModelList.value?.values?.toList() ?: emptyList()
-            val mediaModels = mediaFetcher.fetchAndSave(giphyMediaViewModels, site)
+            val gifMediaViewModels = _selectedMediaViewModelList.value?.values?.toList() ?: emptyList()
+            val mediaModels = mediaFetcher.fetchAndSave(gifMediaViewModels, site)
             DownloadResult(mediaModels = mediaModels)
         } catch (e: CancellationException) {
             // We don't need to handle coroutine cancellations. The UI should just do nothing.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerViewModel.kt
@@ -25,7 +25,7 @@ import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
 /**
- * Holds the data for [org.wordpress.android.ui.giphy.GiphyPickerActivity]
+ * Holds the data for [org.wordpress.android.ui.gif.GifPickerActivity]
  *
  * This creates a [PagedList] which can be bound to by a [PagedListAdapter] and also manages the logic of the
  * selected media. That includes but not limited to keeping the [GifMediaViewModel.selectionNumber] continuous.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/GifPickerViewModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -28,20 +28,20 @@ import javax.inject.Inject
  * Holds the data for [org.wordpress.android.ui.giphy.GiphyPickerActivity]
  *
  * This creates a [PagedList] which can be bound to by a [PagedListAdapter] and also manages the logic of the
- * selected media. That includes but not limited to keeping the [GiphyMediaViewModel.selectionNumber] continuous.
+ * selected media. That includes but not limited to keeping the [GifMediaViewModel.selectionNumber] continuous.
  *
  * Calling [setup] is required before using this ViewModel.
  */
-class GiphyPickerViewModel @Inject constructor(
+class GifPickerViewModel @Inject constructor(
     private val networkUtils: NetworkUtilsWrapper,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val mediaFetcher: GiphyMediaFetcher,
+    private val mediaFetcher: GifMediaFetcher,
     /**
-     * The [GiphyPickerDataSourceFactory] to use
+     * The [GifPickerDataSourceFactory] to use
      *
      * This is only available in the constructor to allow mocking in tests.
      */
-    private val dataSourceFactory: GiphyPickerDataSourceFactory
+    private val dataSourceFactory: GifPickerDataSourceFactory
 ) : CoroutineScopedViewModel() {
     /**
      * A result of [downloadSelected] observed using the [downloadResult] LiveData
@@ -97,7 +97,7 @@ class GiphyPickerViewModel @Inject constructor(
     /**
      * Errors that happened during page loads.
      *
-     * @see [GiphyPickerDataSource.rangeLoadErrorEvent]
+     * @see [GifPickerDataSource.rangeLoadErrorEvent]
      */
     val rangeLoadErrorEvent: LiveData<Throwable> = dataSourceFactory.rangeLoadErrorEvent
 
@@ -115,13 +115,13 @@ class GiphyPickerViewModel @Inject constructor(
      */
     val downloadResult: LiveData<DownloadResult> = _downloadResult
 
-    private val _selectedMediaViewModelList = MutableLiveData<LinkedHashMap<String, GiphyMediaViewModel>>()
+    private val _selectedMediaViewModelList = MutableLiveData<LinkedHashMap<String, GifMediaViewModel>>()
     /**
-     * A [Map] of the [GiphyMediaViewModel]s that were selected by the user
+     * A [Map] of the [GifMediaViewModel]s that were selected by the user
      *
-     * This map is sorted in the order that the user picked them. The [String] is the value of [GiphyMediaViewModel.id].
+     * This map is sorted in the order that the user picked them. The [String] is the value of [GifMediaViewModel.id].
      */
-    val selectedMediaViewModelList: LiveData<LinkedHashMap<String, GiphyMediaViewModel>> = _selectedMediaViewModelList
+    val selectedMediaViewModelList: LiveData<LinkedHashMap<String, GifMediaViewModel>> = _selectedMediaViewModelList
 
     /**
      * Returns `true` if the selection bar (UI) should be shown
@@ -142,7 +142,7 @@ class GiphyPickerViewModel @Inject constructor(
     /**
      * The [PagedList] that should be displayed in the RecyclerView
      */
-    val mediaViewModelPagedList: LiveData<PagedList<GiphyMediaViewModel>> by lazy {
+    val mediaViewModelPagedList: LiveData<PagedList<GifMediaViewModel>> by lazy {
         val pagedListConfig = PagedList.Config.Builder()
                 .setEnablePlaceholders(false)
                 .setInitialLoadSizeHint(DEFAULT_INITIAL_LOAD_SIZE_HINT)
@@ -157,7 +157,7 @@ class GiphyPickerViewModel @Inject constructor(
     /**
      * Update the [emptyDisplayMode] depending on the number of API search results or whether there was an error.
      */
-    private val pagedListBoundaryCallback = object : BoundaryCallback<GiphyMediaViewModel>() {
+    private val pagedListBoundaryCallback = object : BoundaryCallback<GifMediaViewModel>() {
         override fun onZeroItemsLoaded() {
             _isPerformingInitialLoad.postValue(false)
 
@@ -170,7 +170,7 @@ class GiphyPickerViewModel @Inject constructor(
             super.onZeroItemsLoaded()
         }
 
-        override fun onItemAtFrontLoaded(itemAtFront: GiphyMediaViewModel) {
+        override fun onItemAtFrontLoaded(itemAtFront: GifMediaViewModel) {
             _isPerformingInitialLoad.postValue(false)
             _emptyDisplayMode.postValue(EmptyDisplayMode.HIDDEN)
             super.onItemAtFrontLoaded(itemAtFront)
@@ -208,7 +208,7 @@ class GiphyPickerViewModel @Inject constructor(
      * when, presumably, the user has stopped typing.
      *
      * This also clears the [selectedMediaViewModelList]. This makes sense because the user will not be seeing the
-     * currently selected [GiphyMediaViewModel] if the new search query results are different.
+     * currently selected [GifMediaViewModel] if the new search query results are different.
      *
      * Searching is disabled if downloading or the [query] is the same as the last one.
      *
@@ -240,7 +240,7 @@ class GiphyPickerViewModel @Inject constructor(
     }
 
     /**
-     * Downloads all the selected [GiphyMediaViewModel]
+     * Downloads all the selected [GifMediaViewModel]
      *
      * When the process is finished, the results will be posted to [downloadResult].
      *
@@ -285,17 +285,17 @@ class GiphyPickerViewModel @Inject constructor(
     }
 
     /**
-     * Toggles a [GiphyMediaViewModel]'s `isSelected` property between true and false
+     * Toggles a [GifMediaViewModel]'s `isSelected` property between true and false
      *
-     * This also updates the [GiphyMediaViewModel.selectionNumber] of all the objects in [selectedMediaViewModelList].
+     * This also updates the [GifMediaViewModel.selectionNumber] of all the objects in [selectedMediaViewModelList].
      */
-    fun toggleSelected(mediaViewModel: GiphyMediaViewModel) {
+    fun toggleSelected(mediaViewModel: GifMediaViewModel) {
         if (_state.value != State.IDLE) {
             return
         }
 
-        assert(mediaViewModel is MutableGiphyMediaViewModel)
-        mediaViewModel as MutableGiphyMediaViewModel
+        assert(mediaViewModel is MutableGifMediaViewModel)
+        mediaViewModel as MutableGifMediaViewModel
 
         val isSelected = !(mediaViewModel.isSelected.value ?: false)
 
@@ -317,14 +317,14 @@ class GiphyPickerViewModel @Inject constructor(
     }
 
     /**
-     * Update the [GiphyMediaViewModel.selectionNumber] values so that they are continuous
+     * Update the [GifMediaViewModel.selectionNumber] values so that they are continuous
      *
-     * For example, if the selection numbers are [1, 2, 3, 4, 5] and the 2nd [GiphyMediaViewModel] was removed, we
+     * For example, if the selection numbers are [1, 2, 3, 4, 5] and the 2nd [GifMediaViewModel] was removed, we
      * want the selection numbers to be updated to [1, 2, 3, 4] instead of leaving it as [1, 3, 4, 5].
      */
-    private fun rebuildSelectionNumbers(mediaList: LinkedHashMap<String, GiphyMediaViewModel>) {
+    private fun rebuildSelectionNumbers(mediaList: LinkedHashMap<String, GifMediaViewModel>) {
         mediaList.values.forEachIndexed { index, mediaViewModel ->
-            (mediaViewModel as MutableGiphyMediaViewModel).postSelectionNumber(index + 1)
+            (mediaViewModel as MutableGifMediaViewModel).postSelectionNumber(index + 1)
         }
     }
 
@@ -350,7 +350,7 @@ class GiphyPickerViewModel @Inject constructor(
     /**
      * Retries all previously failed page loads.
      *
-     * @see [GiphyPickerDataSource.retryAllFailedRangeLoads]
+     * @see [GifPickerDataSource.retryAllFailedRangeLoads]
      */
     fun retryAllFailedRangeLoads() = dataSourceFactory.retryAllFailedRangeLoads()
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/MutableGifMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/MutableGifMediaViewModel.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.viewmodel.SingleLiveEvent
  * way so that [GifPickerViewModel] encapsulates all the logic of managing selected items as well as keeping their
  * selection numbers continuous.
  *
- * The [GiphyPickerViewHolder] should never have access to the mutating methods of this class.
+ * The [GifPickerViewHolder] should never have access to the mutating methods of this class.
  */
 data class MutableGifMediaViewModel(
     override val id: String,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/MutableGifMediaViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/MutableGifMediaViewModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import android.net.Uri
 import androidx.lifecycle.LiveData
@@ -6,21 +6,21 @@ import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.viewmodel.SingleLiveEvent
 
 /**
- * A mutable implementation of [GiphyMediaViewModel]
+ * A mutable implementation of [GifMediaViewModel]
  *
- * This is meant to be accessible by [GiphyPickerViewModel] and [GiphyPickerDataSource] only. This is designed this
- * way so that [GiphyPickerViewModel] encapsulates all the logic of managing selected items as well as keeping their
+ * This is meant to be accessible by [GifPickerViewModel] and [GifPickerDataSource] only. This is designed this
+ * way so that [GifPickerViewModel] encapsulates all the logic of managing selected items as well as keeping their
  * selection numbers continuous.
  *
  * The [GiphyPickerViewHolder] should never have access to the mutating methods of this class.
  */
-data class MutableGiphyMediaViewModel(
+data class MutableGifMediaViewModel(
     override val id: String,
     override val thumbnailUri: Uri,
     override val previewImageUri: Uri,
     override val largeImageUri: Uri,
     override val title: String
-) : GiphyMediaViewModel {
+) : GifMediaViewModel {
     /**
      * Using [SingleLiveEvent] will prevent calls like this from running immediately when a ViewHolder is bound:
      *

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/provider/GifProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/provider/GifProvider.kt
@@ -1,6 +1,6 @@
-package org.wordpress.android.viewmodel.giphy.provider
+package org.wordpress.android.viewmodel.gif.provider
 
-import org.wordpress.android.viewmodel.giphy.GiphyMediaViewModel
+import org.wordpress.android.viewmodel.gif.GifMediaViewModel
 
 /**
  * Interface to interact with a GIF provider API avoiding coupling with the concrete implementation
@@ -13,7 +13,7 @@ interface GifProvider {
      * @param position to request results starting from a given position for that query
      * @param loadSize to request a result list limited to a specific amount
      * @param onSuccess will be called if the Provider had success finding GIFs
-     * and will deliver a [List] of [GiphyMediaViewModel] with all matching GIFs
+     * and will deliver a [List] of [GifMediaViewModel] with all matching GIFs
      * and a [Int] describing the next position for pagination
      * @param onFailure will be called if the Provider didn't succeed with the task of bringing GIFs,
      * the delivered String will describe the error to be presented to the user
@@ -22,7 +22,7 @@ interface GifProvider {
         query: String,
         position: Int,
         loadSize: Int? = null,
-        onSuccess: (List<GiphyMediaViewModel>, Int?) -> Unit,
+        onSuccess: (List<GifMediaViewModel>, Int?) -> Unit,
         onFailure: (Throwable) -> Unit
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/provider/TenorProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/provider/TenorProvider.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy.provider
+package org.wordpress.android.viewmodel.gif.provider
 
 import android.content.Context
 import android.net.Uri
@@ -10,9 +10,9 @@ import com.tenor.android.core.network.ApiClient
 import com.tenor.android.core.network.IApiClient
 import com.tenor.android.core.response.impl.GifsResponse
 import org.wordpress.android.R.string
-import org.wordpress.android.viewmodel.giphy.GiphyMediaViewModel
-import org.wordpress.android.viewmodel.giphy.MutableGiphyMediaViewModel
-import org.wordpress.android.viewmodel.giphy.provider.GifProvider.GifRequestFailedException
+import org.wordpress.android.viewmodel.gif.GifMediaViewModel
+import org.wordpress.android.viewmodel.gif.MutableGifMediaViewModel
+import org.wordpress.android.viewmodel.gif.provider.GifProvider.GifRequestFailedException
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -31,7 +31,7 @@ internal class TenorProvider constructor(
      * Implementation of the [GifProvider] search method, it will call the Tenor client search
      * right away with the provided parameters.
      *
-     * If the search request succeeds an [List] of [MutableGiphyMediaViewModel] will be passed with the next position
+     * If the search request succeeds an [List] of [MutableGifMediaViewModel] will be passed with the next position
      * for pagination. If there's no next position provided, it will be passed as null.
      *
      * If the search request fails an [GifRequestFailedException] will be passed with the API
@@ -42,7 +42,7 @@ internal class TenorProvider constructor(
         query: String,
         position: Int,
         loadSize: Int?,
-        onSuccess: (List<GiphyMediaViewModel>, Int?) -> Unit,
+        onSuccess: (List<GifMediaViewModel>, Int?) -> Unit,
         onFailure: (Throwable) -> Unit
     ) {
         tenorClient.enqueueSearchRequest(
@@ -110,10 +110,10 @@ internal class TenorProvider constructor(
 
     /**
      * Every GIF returned by the Tenor will be available as [Result], to better interface
-     * with our app, it will be converted to [MutableGiphyMediaViewModel] to avoid any external
+     * with our app, it will be converted to [MutableGifMediaViewModel] to avoid any external
      * coupling with the Tenor API
      */
-    private fun Result.toMutableGifMediaViewModel() = MutableGiphyMediaViewModel(
+    private fun Result.toMutableGifMediaViewModel() = MutableGifMediaViewModel(
             id,
             Uri.parse(urlFromCollectionFormat(MediaCollectionFormat.GIF_NANO)),
             Uri.parse(urlFromCollectionFormat(MediaCollectionFormat.GIF_TINY)),

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/provider/TenorProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/gif/provider/TenorProvider.kt
@@ -55,7 +55,7 @@ internal class TenorProvider constructor(
                     onSuccess(gifList, nextPosition)
                 },
                 onFailure = {
-                    val errorMessage = it?.message ?: context.getString(string.gifs_list_search_returned_unknown_error)
+                    val errorMessage = it?.message ?: context.getString(string.gif_list_search_returned_unknown_error)
                     onFailure(GifRequestFailedException(errorMessage))
                 }
         )
@@ -78,7 +78,7 @@ internal class TenorProvider constructor(
     ) = buildSearchCall(query, loadSize, position).apply {
         enqueue(object : Callback<GifsResponse> {
             override fun onResponse(call: Call<GifsResponse>, response: Response<GifsResponse>) {
-                val defaultErrorMessage = context.getString(string.giphy_picker_empty_search_list)
+                val defaultErrorMessage = context.getString(string.gif_picker_empty_search_list)
                 response.body()?.let(onSuccess) ?: onFailure(GifRequestFailedException(defaultErrorMessage))
             }
 
@@ -112,6 +112,8 @@ internal class TenorProvider constructor(
      * Every GIF returned by the Tenor will be available as [Result], to better interface
      * with our app, it will be converted to [MutableGifMediaViewModel] to avoid any external
      * coupling with the Tenor API
+     *
+     * See the [Tenor API docs](https://tenor.com/gifapi/documentation#responseobjects) for more information on what a [Result] object contains.
      */
     private fun Result.toMutableGifMediaViewModel() = MutableGifMediaViewModel(
             id,

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -554,11 +554,6 @@ Language: ar
     <string name="stats_no_data_for_period">لا توجد بيانات لهذه الفترة</string>
     <string name="preference_strip_image_location">إزالة موقع من الوسائط</string>
     <string name="stats_cannot_be_started">يتعذر علينا فتح الإحصاءات في الوقت الحالي. يرجى المحاولة مجددًا في وقت لاحق</string>
-    <string name="gif_powered_by_tenor">مدعون من TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">فشل تحميل بعض الوسائط بسبب وجود خطأ في الشبكة.</string>
-    <string name="gif_picker_empty_search_list">لا توجد وسائط مطابقة لبحثك</string>
-    <string name="gif_picker_initial_empty_text">ابحث للعثور على صور بتنسيق GIF لإضافتها إلى مكتبة الوسائط الخاصة بك!</string>
-    <string name="gif_picker_search_hint">البحث في Tenor</string>
     <string name="stats_author_views_label">مشاهدات</string>
     <string name="stats_author_label">الكاتب</string>
     <string name="stats_authors">الكُتّاب</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -554,11 +554,11 @@ Language: ar
     <string name="stats_no_data_for_period">لا توجد بيانات لهذه الفترة</string>
     <string name="preference_strip_image_location">إزالة موقع من الوسائط</string>
     <string name="stats_cannot_be_started">يتعذر علينا فتح الإحصاءات في الوقت الحالي. يرجى المحاولة مجددًا في وقت لاحق</string>
-    <string name="giphy_powered_by_giphy">مدعون من GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">فشل تحميل بعض الوسائط بسبب وجود خطأ في الشبكة.</string>
-    <string name="giphy_picker_empty_search_list">لا توجد وسائط مطابقة لبحثك</string>
-    <string name="giphy_picker_initial_empty_text">ابحث للعثور على صور بتنسيق GIF لإضافتها إلى مكتبة الوسائط الخاصة بك!</string>
-    <string name="giphy_picker_search_hint">البحث في Giphy</string>
+    <string name="gif_powered_by_tenor">مدعون من TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">فشل تحميل بعض الوسائط بسبب وجود خطأ في الشبكة.</string>
+    <string name="gif_picker_empty_search_list">لا توجد وسائط مطابقة لبحثك</string>
+    <string name="gif_picker_initial_empty_text">ابحث للعثور على صور بتنسيق GIF لإضافتها إلى مكتبة الوسائط الخاصة بك!</string>
+    <string name="gif_picker_search_hint">البحث في Tenor</string>
     <string name="stats_author_views_label">مشاهدات</string>
     <string name="stats_author_label">الكاتب</string>
     <string name="stats_authors">الكُتّاب</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -101,11 +101,9 @@ Language: cs_CZ
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autoři</string>
     <string name="stats_videos_views_label">Zobrazení</string>
-    <string name="gif_powered_by_tenor">Powered by TENOR</string>
     <string name="stats_insights_view_more">Zobrazit více</string>
     <string name="stats_insights_share_post">Sdílet příspěvek</string>
     <string name="stats_insights_create_post">Vytvořit příspěvek</string>
-    <string name="gif_picker_search_hint">Prohledat Tenor</string>
     <string name="stats_search_terms_label">Hledaný výraz</string>
     <string name="stats_search_terms">Hledaný výrazy</string>
     <string name="stats_clicks_label">Kliknutí</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -101,11 +101,11 @@ Language: cs_CZ
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autoři</string>
     <string name="stats_videos_views_label">Zobrazení</string>
-    <string name="giphy_powered_by_giphy">Powered by GIPHY</string>
+    <string name="gif_powered_by_tenor">Powered by TENOR</string>
     <string name="stats_insights_view_more">Zobrazit více</string>
     <string name="stats_insights_share_post">Sdílet příspěvek</string>
     <string name="stats_insights_create_post">Vytvořit příspěvek</string>
-    <string name="giphy_picker_search_hint">Prohledat Giphy</string>
+    <string name="gif_picker_search_hint">Prohledat Tenor</string>
     <string name="stats_search_terms_label">Hledaný výraz</string>
     <string name="stats_search_terms">Hledaný výrazy</string>
     <string name="stats_clicks_label">Kliknutí</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -554,11 +554,11 @@ Language: de
     <string name="stats_no_data_for_period">Keine Daten für diesen Zeitraum</string>
     <string name="preference_strip_image_location">Positionsangabe von Medien entfernen</string>
     <string name="stats_cannot_be_started">Wir können die Statistiken momentan nicht öffnen. Bitte versuche es später erneut</string>
-    <string name="giphy_powered_by_giphy">Bereitgestellt von GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Einige Medien konnten aufgrund eines Netzwerkfehlers nicht geladen werden.</string>
-    <string name="giphy_picker_empty_search_list">Keine Medien entsprechen deiner Suche</string>
-    <string name="giphy_picker_initial_empty_text">Suche nach GIFs, die du deiner Mediathek hinzufügen kannst!</string>
-    <string name="giphy_picker_search_hint">Giphy durchsuchen</string>
+    <string name="gif_powered_by_tenor">Bereitgestellt von TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Einige Medien konnten aufgrund eines Netzwerkfehlers nicht geladen werden.</string>
+    <string name="gif_picker_empty_search_list">Keine Medien entsprechen deiner Suche</string>
+    <string name="gif_picker_initial_empty_text">Suche nach GIFs, die du deiner Mediathek hinzufügen kannst!</string>
+    <string name="gif_picker_search_hint">Tenor durchsuchen</string>
     <string name="stats_author_views_label">Aufrufe</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autoren</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -554,11 +554,6 @@ Language: de
     <string name="stats_no_data_for_period">Keine Daten für diesen Zeitraum</string>
     <string name="preference_strip_image_location">Positionsangabe von Medien entfernen</string>
     <string name="stats_cannot_be_started">Wir können die Statistiken momentan nicht öffnen. Bitte versuche es später erneut</string>
-    <string name="gif_powered_by_tenor">Bereitgestellt von TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Einige Medien konnten aufgrund eines Netzwerkfehlers nicht geladen werden.</string>
-    <string name="gif_picker_empty_search_list">Keine Medien entsprechen deiner Suche</string>
-    <string name="gif_picker_initial_empty_text">Suche nach GIFs, die du deiner Mediathek hinzufügen kannst!</string>
-    <string name="gif_picker_search_hint">Tenor durchsuchen</string>
     <string name="stats_author_views_label">Aufrufe</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autoren</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -62,7 +62,6 @@ Language: el_GR
     <string name="new_site_creation_screen_title_step_count">%1$d από %2$d</string>
     <string name="new_site_creation_screen_title_general">Δημιουργία ιστότοπου</string>
     <string name="snackbar_conflict_undo">Αναίρεση</string>
-    <string name="gif_picker_search_hint">Αναζήτηση στο Tenor</string>
     <string name="stats_author_views_label">Προβολές</string>
     <string name="stats_author_label">Συγγραφέας</string>
     <string name="stats_authors">Συγγραφείς</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -62,7 +62,7 @@ Language: el_GR
     <string name="new_site_creation_screen_title_step_count">%1$d από %2$d</string>
     <string name="new_site_creation_screen_title_general">Δημιουργία ιστότοπου</string>
     <string name="snackbar_conflict_undo">Αναίρεση</string>
-    <string name="giphy_picker_search_hint">Αναζήτηση στο Giphy</string>
+    <string name="gif_picker_search_hint">Αναζήτηση στο Tenor</string>
     <string name="stats_author_views_label">Προβολές</string>
     <string name="stats_author_label">Συγγραφέας</string>
     <string name="stats_authors">Συγγραφείς</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -392,11 +392,6 @@ Language: en_AU
     <string name="stats_no_data_for_period">No data for this period</string>
     <string name="preference_strip_image_location">Remove location from media</string>
     <string name="stats_cannot_be_started">We cannot open the statistics at the moment. Please try again later</string>
-    <string name="gif_powered_by_tenor">Powered by TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
-    <string name="gif_picker_empty_search_list">No media matching your search</string>
-    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
-    <string name="gif_picker_search_hint">Search Tenor</string>
     <string name="stats_author_views_label">Views</string>
     <string name="stats_author_label">Author</string>
     <string name="stats_authors">Authors</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -392,11 +392,11 @@ Language: en_AU
     <string name="stats_no_data_for_period">No data for this period</string>
     <string name="preference_strip_image_location">Remove location from media</string>
     <string name="stats_cannot_be_started">We cannot open the statistics at the moment. Please try again later</string>
-    <string name="giphy_powered_by_giphy">Powered by GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
-    <string name="giphy_picker_empty_search_list">No media matching your search</string>
-    <string name="giphy_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
-    <string name="giphy_picker_search_hint">Search Giphy</string>
+    <string name="gif_powered_by_tenor">Powered by TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
+    <string name="gif_picker_empty_search_list">No media matching your search</string>
+    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
+    <string name="gif_picker_search_hint">Search Tenor</string>
     <string name="stats_author_views_label">Views</string>
     <string name="stats_author_label">Author</string>
     <string name="stats_authors">Authors</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -487,11 +487,6 @@ Language: en_CA
     <string name="stats_no_data_for_period">No data for this period</string>
     <string name="preference_strip_image_location">Remove location from media</string>
     <string name="stats_cannot_be_started">We cannot open the statistics at the moment. Please try again later</string>
-    <string name="gif_powered_by_tenor">Powered by TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
-    <string name="gif_picker_empty_search_list">No media matching your search</string>
-    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
-    <string name="gif_picker_search_hint">Search Tenor</string>
     <string name="stats_author_views_label">Views</string>
     <string name="stats_author_label">Author</string>
     <string name="stats_authors">Authors</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -487,11 +487,11 @@ Language: en_CA
     <string name="stats_no_data_for_period">No data for this period</string>
     <string name="preference_strip_image_location">Remove location from media</string>
     <string name="stats_cannot_be_started">We cannot open the statistics at the moment. Please try again later</string>
-    <string name="giphy_powered_by_giphy">Powered by GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
-    <string name="giphy_picker_empty_search_list">No media matching your search</string>
-    <string name="giphy_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
-    <string name="giphy_picker_search_hint">Search Giphy</string>
+    <string name="gif_powered_by_tenor">Powered by TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
+    <string name="gif_picker_empty_search_list">No media matching your search</string>
+    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
+    <string name="gif_picker_search_hint">Search Tenor</string>
     <string name="stats_author_views_label">Views</string>
     <string name="stats_author_label">Author</string>
     <string name="stats_authors">Authors</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -554,11 +554,11 @@ Language: en_GB
     <string name="stats_no_data_for_period">No data for this period</string>
     <string name="preference_strip_image_location">Remove location from media</string>
     <string name="stats_cannot_be_started">We cannot open the statistics at the moment. Please try again later</string>
-    <string name="giphy_powered_by_giphy">Powered by GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
-    <string name="giphy_picker_empty_search_list">No media matching your search</string>
-    <string name="giphy_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
-    <string name="giphy_picker_search_hint">Search Giphy</string>
+    <string name="gif_powered_by_tenor">Powered by TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
+    <string name="gif_picker_empty_search_list">No media matching your search</string>
+    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
+    <string name="gif_picker_search_hint">Search Tenor</string>
     <string name="stats_author_views_label">Views</string>
     <string name="stats_author_label">Author</string>
     <string name="stats_authors">Authors</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -554,11 +554,6 @@ Language: en_GB
     <string name="stats_no_data_for_period">No data for this period</string>
     <string name="preference_strip_image_location">Remove location from media</string>
     <string name="stats_cannot_be_started">We cannot open the statistics at the moment. Please try again later</string>
-    <string name="gif_powered_by_tenor">Powered by TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
-    <string name="gif_picker_empty_search_list">No media matching your search</string>
-    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
-    <string name="gif_picker_search_hint">Search Tenor</string>
     <string name="stats_author_views_label">Views</string>
     <string name="stats_author_label">Author</string>
     <string name="stats_authors">Authors</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -149,11 +149,6 @@ Language: es_CL
     <string name="stats_no_data_for_period">No hay datos para este período</string>
     <string name="preference_strip_image_location">Quita la ubicación de los medios</string>
     <string name="stats_cannot_be_started">No podemos abrir las estadísticas en este momento. Por favor inténtalo de nuevo más tarde</string>
-    <string name="gif_powered_by_tenor">Desarrollado por TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Algunos medios no pudieron cargarse debido a un error de red.</string>
-    <string name="gif_picker_empty_search_list">No hay medios que coincidan con tu búsqueda</string>
-    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIFs para añadirlos a tu Biblioteca de Medios!</string>
-    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_author_views_label">Vistas</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -149,11 +149,11 @@ Language: es_CL
     <string name="stats_no_data_for_period">No hay datos para este período</string>
     <string name="preference_strip_image_location">Quita la ubicación de los medios</string>
     <string name="stats_cannot_be_started">No podemos abrir las estadísticas en este momento. Por favor inténtalo de nuevo más tarde</string>
-    <string name="giphy_powered_by_giphy">Desarrollado por GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Algunos medios no pudieron cargarse debido a un error de red.</string>
-    <string name="giphy_picker_empty_search_list">No hay medios que coincidan con tu búsqueda</string>
-    <string name="giphy_picker_initial_empty_text">¡Busca para encontrar GIFs para añadirlos a tu Biblioteca de Medios!</string>
-    <string name="giphy_picker_search_hint">Buscar en Giphy</string>
+    <string name="gif_powered_by_tenor">Desarrollado por TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Algunos medios no pudieron cargarse debido a un error de red.</string>
+    <string name="gif_picker_empty_search_list">No hay medios que coincidan con tu búsqueda</string>
+    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIFs para añadirlos a tu Biblioteca de Medios!</string>
+    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_author_views_label">Vistas</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -555,11 +555,11 @@ Language: es_MX
     <string name="preference_strip_image_location">Eliminar la ubicación de los medios</string>
     <string name="stats_cannot_be_started">No podemos abrir las estadísticas en este momento. Por favor inténtalo de nuevo más tarde</string>
     <string name="stats_insights_share_post">Compartir publicacion</string>
-    <string name="giphy_powered_by_giphy">Desarrollado por GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Algunos medios no se pudieron cargar debido a un error de red.</string>
-    <string name="giphy_picker_empty_search_list">No hay medios que coincidan con tu búsqueda.</string>
-    <string name="giphy_picker_initial_empty_text">¡Busca para encontrar GIFs para agregar a tu biblioteca de medios!</string>
-    <string name="giphy_picker_search_hint">Buscar en Giphy</string>
+    <string name="gif_powered_by_tenor">Desarrollado por TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Algunos medios no se pudieron cargar debido a un error de red.</string>
+    <string name="gif_picker_empty_search_list">No hay medios que coincidan con tu búsqueda.</string>
+    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIFs para agregar a tu biblioteca de medios!</string>
+    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_author_views_label">Vistas</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -555,11 +555,6 @@ Language: es_MX
     <string name="preference_strip_image_location">Eliminar la ubicación de los medios</string>
     <string name="stats_cannot_be_started">No podemos abrir las estadísticas en este momento. Por favor inténtalo de nuevo más tarde</string>
     <string name="stats_insights_share_post">Compartir publicacion</string>
-    <string name="gif_powered_by_tenor">Desarrollado por TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Algunos medios no se pudieron cargar debido a un error de red.</string>
-    <string name="gif_picker_empty_search_list">No hay medios que coincidan con tu búsqueda.</string>
-    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIFs para agregar a tu biblioteca de medios!</string>
-    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_author_views_label">Vistas</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -554,11 +554,6 @@ Language: es_VE
     <string name="stats_no_data_for_period">No hay datos en este periodo</string>
     <string name="preference_strip_image_location">Eliminar la ubicación de los medios</string>
     <string name="stats_cannot_be_started">No podemos abrir las estadísticas en este momento. Por favor, inténtalo de nuevo más tarde</string>
-    <string name="gif_powered_by_tenor">Creado por TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Algunos medios no se cargaron debido a un error de red.</string>
-    <string name="gif_picker_empty_search_list">Ningún medio coincide con tu búsqueda</string>
-    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIFs para añadir a tu biblioteca de medios!</string>
-    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_author_views_label">Vistas</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -554,11 +554,11 @@ Language: es_VE
     <string name="stats_no_data_for_period">No hay datos en este periodo</string>
     <string name="preference_strip_image_location">Eliminar la ubicación de los medios</string>
     <string name="stats_cannot_be_started">No podemos abrir las estadísticas en este momento. Por favor, inténtalo de nuevo más tarde</string>
-    <string name="giphy_powered_by_giphy">Creado por GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Algunos medios no se cargaron debido a un error de red.</string>
-    <string name="giphy_picker_empty_search_list">Ningún medio coincide con tu búsqueda</string>
-    <string name="giphy_picker_initial_empty_text">¡Busca para encontrar GIFs para añadir a tu biblioteca de medios!</string>
-    <string name="giphy_picker_search_hint">Buscar en Giphy</string>
+    <string name="gif_powered_by_tenor">Creado por TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Algunos medios no se cargaron debido a un error de red.</string>
+    <string name="gif_picker_empty_search_list">Ningún medio coincide con tu búsqueda</string>
+    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIFs para añadir a tu biblioteca de medios!</string>
+    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_author_views_label">Vistas</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -582,12 +582,12 @@ Language: es
     <string name="stats_insights_view_more">Ver más</string>
     <string name="stats_insights_share_post">Compartir entrada</string>
     <string name="stats_insights_create_post">Crear entrada</string>
-    <string name="giphy_powered_by_giphy">Creado por GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Algunos medios no se cargaron debido a un error de red.</string>
-    <string name="giphy_picker_empty_search_list">Ningún medio coincide con tu búsqueda</string>
-    <string name="giphy_picker_search_hint">Buscar en Giphy</string>
+    <string name="gif_powered_by_tenor">Creado por TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Algunos medios no se cargaron debido a un error de red.</string>
+    <string name="gif_picker_empty_search_list">Ningún medio coincide con tu búsqueda</string>
+    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_insights_latest_post_message">Han pasado %1$s desde que se publicó %2$s. Así es como ha funcionado la entrada hasta ahora:</string>
-    <string name="giphy_picker_initial_empty_text">¡Busca para encontrar GIF para añadir a tu biblioteca de medios!</string>
+    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIF para añadir a tu biblioteca de medios!</string>
     <string name="stats_insights_tags_and_categories">Etiquetas y categorías</string>
     <string name="stats_insights_latest_post_with_no_engagement">Han pasado %1$s desde que se publicó %2$s. Pon la bola a rodar y aumenta las vistas de las entradas compartiendo tu entrada:</string>
     <string name="stats_insights_latest_post_empty">Aún no has publicado ninguna entrada. Una vez que empieces a publicar, el resumen de tu última entrada aparecerá aquí:</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -582,12 +582,7 @@ Language: es
     <string name="stats_insights_view_more">Ver más</string>
     <string name="stats_insights_share_post">Compartir entrada</string>
     <string name="stats_insights_create_post">Crear entrada</string>
-    <string name="gif_powered_by_tenor">Creado por TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Algunos medios no se cargaron debido a un error de red.</string>
-    <string name="gif_picker_empty_search_list">Ningún medio coincide con tu búsqueda</string>
-    <string name="gif_picker_search_hint">Buscar en Tenor</string>
     <string name="stats_insights_latest_post_message">Han pasado %1$s desde que se publicó %2$s. Así es como ha funcionado la entrada hasta ahora:</string>
-    <string name="gif_picker_initial_empty_text">¡Busca para encontrar GIF para añadir a tu biblioteca de medios!</string>
     <string name="stats_insights_tags_and_categories">Etiquetas y categorías</string>
     <string name="stats_insights_latest_post_with_no_engagement">Han pasado %1$s desde que se publicó %2$s. Pon la bola a rodar y aumenta las vistas de las entradas compartiendo tu entrada:</string>
     <string name="stats_insights_latest_post_empty">Aún no has publicado ninguna entrada. Una vez que empieces a publicar, el resumen de tu última entrada aparecerá aquí:</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -552,11 +552,6 @@ Language: fr
     <string name="stats_no_data_for_period">Aucune donnée pour cette période</string>
     <string name="preference_strip_image_location">Supprimer les données de localisation des photos et vidéos</string>
     <string name="stats_cannot_be_started">Nous ne pouvons pas ouvrir les statistiques pour le moment. Veuillez réessayer plus tard</string>
-    <string name="gif_powered_by_tenor">Optimisé par TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Échec de chargement de certains médias à cause d’une erreur réseau.</string>
-    <string name="gif_picker_empty_search_list">Aucun média ne correspond à votre recherche.</string>
-    <string name="gif_picker_initial_empty_text">Recherchez des GIF à ajouter à votre bibliothèque de médias !</string>
-    <string name="gif_picker_search_hint">Rechercher Tenor</string>
     <string name="stats_author_views_label">Vues</string>
     <string name="stats_author_label">Auteur</string>
     <string name="stats_authors">Auteurs</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -552,11 +552,11 @@ Language: fr
     <string name="stats_no_data_for_period">Aucune donnée pour cette période</string>
     <string name="preference_strip_image_location">Supprimer les données de localisation des photos et vidéos</string>
     <string name="stats_cannot_be_started">Nous ne pouvons pas ouvrir les statistiques pour le moment. Veuillez réessayer plus tard</string>
-    <string name="giphy_powered_by_giphy">Optimisé par GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Échec de chargement de certains médias à cause d’une erreur réseau.</string>
-    <string name="giphy_picker_empty_search_list">Aucun média ne correspond à votre recherche.</string>
-    <string name="giphy_picker_initial_empty_text">Recherchez des GIF à ajouter à votre bibliothèque de médias !</string>
-    <string name="giphy_picker_search_hint">Rechercher Giphy</string>
+    <string name="gif_powered_by_tenor">Optimisé par TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Échec de chargement de certains médias à cause d’une erreur réseau.</string>
+    <string name="gif_picker_empty_search_list">Aucun média ne correspond à votre recherche.</string>
+    <string name="gif_picker_initial_empty_text">Recherchez des GIF à ajouter à votre bibliothèque de médias !</string>
+    <string name="gif_picker_search_hint">Rechercher Tenor</string>
     <string name="stats_author_views_label">Vues</string>
     <string name="stats_author_label">Auteur</string>
     <string name="stats_authors">Auteurs</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -553,11 +553,11 @@ Language: he_IL
     <string name="stats_no_data_for_period">אין נתונים לתקופה זו</string>
     <string name="preference_strip_image_location">הסרת מיקום ממדיה</string>
     <string name="stats_cannot_be_started">אין לנו אפשרות לפתוח את הנתונים הסטטיסטיים כעת. יש לנסות שוב מאוחר יותר</string>
-    <string name="giphy_powered_by_giphy">מופעל באמצעות GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">הטעינה של חלק מקובצי המדיה נכשלה עקב שגיאת רשת.</string>
-    <string name="giphy_picker_empty_search_list">לא נמצאו פרטי מדיה שמתאימים לחיפוש שלך</string>
-    <string name="giphy_picker_initial_empty_text">חיפוש קובצי GIF שניתן להוסיף לספריית מדיה שלך!</string>
-    <string name="giphy_picker_search_hint">חיפוש ב-Giphy</string>
+    <string name="gif_powered_by_tenor">מופעל באמצעות TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">הטעינה של חלק מקובצי המדיה נכשלה עקב שגיאת רשת.</string>
+    <string name="gif_picker_empty_search_list">לא נמצאו פרטי מדיה שמתאימים לחיפוש שלך</string>
+    <string name="gif_picker_initial_empty_text">חיפוש קובצי GIF שניתן להוסיף לספריית מדיה שלך!</string>
+    <string name="gif_picker_search_hint">חיפוש ב-Tenor</string>
     <string name="stats_author_views_label">צפיות</string>
     <string name="stats_author_label">מחבר</string>
     <string name="stats_authors">מחברים</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -553,11 +553,6 @@ Language: he_IL
     <string name="stats_no_data_for_period">אין נתונים לתקופה זו</string>
     <string name="preference_strip_image_location">הסרת מיקום ממדיה</string>
     <string name="stats_cannot_be_started">אין לנו אפשרות לפתוח את הנתונים הסטטיסטיים כעת. יש לנסות שוב מאוחר יותר</string>
-    <string name="gif_powered_by_tenor">מופעל באמצעות TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">הטעינה של חלק מקובצי המדיה נכשלה עקב שגיאת רשת.</string>
-    <string name="gif_picker_empty_search_list">לא נמצאו פרטי מדיה שמתאימים לחיפוש שלך</string>
-    <string name="gif_picker_initial_empty_text">חיפוש קובצי GIF שניתן להוסיף לספריית מדיה שלך!</string>
-    <string name="gif_picker_search_hint">חיפוש ב-Tenor</string>
     <string name="stats_author_views_label">צפיות</string>
     <string name="stats_author_label">מחבר</string>
     <string name="stats_authors">מחברים</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -550,11 +550,11 @@ Language: id
     <string name="stats_no_data_for_period">Tidak ada data selama periode ini</string>
     <string name="preference_strip_image_location">Hapus lokasi dari media</string>
     <string name="stats_cannot_be_started">Saat ini kami tidak dapat membuka statistik. Harap coba lagi nanti</string>
-    <string name="giphy_powered_by_giphy">Didukung oleh GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Sebagian media gagal dimuat karena terdapat error jaringan.</string>
-    <string name="giphy_picker_empty_search_list">Tidak ada media yang cocok dengan pencarian Anda</string>
-    <string name="giphy_picker_initial_empty_text">Cari GIF untuk ditambahkan ke Pustaka Media Anda!</string>
-    <string name="giphy_picker_search_hint">Cari di Giphy</string>
+    <string name="gif_powered_by_tenor">Didukung oleh TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Sebagian media gagal dimuat karena terdapat error jaringan.</string>
+    <string name="gif_picker_empty_search_list">Tidak ada media yang cocok dengan pencarian Anda</string>
+    <string name="gif_picker_initial_empty_text">Cari GIF untuk ditambahkan ke Pustaka Media Anda!</string>
+    <string name="gif_picker_search_hint">Cari di Tenor</string>
     <string name="stats_author_views_label">Tampilan</string>
     <string name="stats_author_label">Penulis</string>
     <string name="stats_authors">Penulis</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -550,11 +550,6 @@ Language: id
     <string name="stats_no_data_for_period">Tidak ada data selama periode ini</string>
     <string name="preference_strip_image_location">Hapus lokasi dari media</string>
     <string name="stats_cannot_be_started">Saat ini kami tidak dapat membuka statistik. Harap coba lagi nanti</string>
-    <string name="gif_powered_by_tenor">Didukung oleh TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Sebagian media gagal dimuat karena terdapat error jaringan.</string>
-    <string name="gif_picker_empty_search_list">Tidak ada media yang cocok dengan pencarian Anda</string>
-    <string name="gif_picker_initial_empty_text">Cari GIF untuk ditambahkan ke Pustaka Media Anda!</string>
-    <string name="gif_picker_search_hint">Cari di Tenor</string>
     <string name="stats_author_views_label">Tampilan</string>
     <string name="stats_author_label">Penulis</string>
     <string name="stats_authors">Penulis</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -538,11 +538,6 @@ Language: it
     <string name="stats_no_data_for_period">Nessun dato per questo periodo</string>
     <string name="preference_strip_image_location">Rimuovi posizione dal contenuto multimediale</string>
     <string name="stats_cannot_be_started">Non è possibile aprire le statistiche. Riprova più tardi</string>
-    <string name="gif_powered_by_tenor">Powered by TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Alcuni caricamenti multimediali non sono riusciti a causa di un errore di rete.</string>
-    <string name="gif_picker_empty_search_list">Nessun media corrispondente alla tua ricerca</string>
-    <string name="gif_picker_initial_empty_text">Cerca per trovare GIF da aggiungere alla tua Libreria multimediale!</string>
-    <string name="gif_picker_search_hint">Cerca in Tenor</string>
     <string name="stats_author_views_label">Visualizzazioni</string>
     <string name="stats_author_label">Autore</string>
     <string name="stats_authors">Autori</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -538,11 +538,11 @@ Language: it
     <string name="stats_no_data_for_period">Nessun dato per questo periodo</string>
     <string name="preference_strip_image_location">Rimuovi posizione dal contenuto multimediale</string>
     <string name="stats_cannot_be_started">Non è possibile aprire le statistiche. Riprova più tardi</string>
-    <string name="giphy_powered_by_giphy">Powered by GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Alcuni caricamenti multimediali non sono riusciti a causa di un errore di rete.</string>
-    <string name="giphy_picker_empty_search_list">Nessun media corrispondente alla tua ricerca</string>
-    <string name="giphy_picker_initial_empty_text">Cerca per trovare GIF da aggiungere alla tua Libreria multimediale!</string>
-    <string name="giphy_picker_search_hint">Cerca in Giphy</string>
+    <string name="gif_powered_by_tenor">Powered by TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Alcuni caricamenti multimediali non sono riusciti a causa di un errore di rete.</string>
+    <string name="gif_picker_empty_search_list">Nessun media corrispondente alla tua ricerca</string>
+    <string name="gif_picker_initial_empty_text">Cerca per trovare GIF da aggiungere alla tua Libreria multimediale!</string>
+    <string name="gif_picker_search_hint">Cerca in Tenor</string>
     <string name="stats_author_views_label">Visualizzazioni</string>
     <string name="stats_author_label">Autore</string>
     <string name="stats_authors">Autori</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -554,11 +554,6 @@ Language: ja_JP
     <string name="stats_no_data_for_period">この期間のデータがありません</string>
     <string name="preference_strip_image_location">メディアから位置情報を削除する</string>
     <string name="stats_cannot_be_started">現在統計を開けません。後ほど、もう一度お試しください</string>
-    <string name="gif_powered_by_tenor">Powered by TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">ネットワークエラーにより一部のメディアが読み込めませんでした。</string>
-    <string name="gif_picker_empty_search_list">検索と一致するメディアがありません</string>
-    <string name="gif_picker_initial_empty_text">GIF を検索して、メディアライブラリに追加してください。</string>
-    <string name="gif_picker_search_hint">Tenor を検索する</string>
     <string name="stats_author_views_label">表示回数</string>
     <string name="stats_author_label">投稿者</string>
     <string name="stats_authors">投稿者</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -554,11 +554,11 @@ Language: ja_JP
     <string name="stats_no_data_for_period">この期間のデータがありません</string>
     <string name="preference_strip_image_location">メディアから位置情報を削除する</string>
     <string name="stats_cannot_be_started">現在統計を開けません。後ほど、もう一度お試しください</string>
-    <string name="giphy_powered_by_giphy">Powered by GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">ネットワークエラーにより一部のメディアが読み込めませんでした。</string>
-    <string name="giphy_picker_empty_search_list">検索と一致するメディアがありません</string>
-    <string name="giphy_picker_initial_empty_text">GIF を検索して、メディアライブラリに追加してください。</string>
-    <string name="giphy_picker_search_hint">Giphy を検索する</string>
+    <string name="gif_powered_by_tenor">Powered by TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">ネットワークエラーにより一部のメディアが読み込めませんでした。</string>
+    <string name="gif_picker_empty_search_list">検索と一致するメディアがありません</string>
+    <string name="gif_picker_initial_empty_text">GIF を検索して、メディアライブラリに追加してください。</string>
+    <string name="gif_picker_search_hint">Tenor を検索する</string>
     <string name="stats_author_views_label">表示回数</string>
     <string name="stats_author_label">投稿者</string>
     <string name="stats_authors">投稿者</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -316,11 +316,11 @@ Language: ku_TR
     <string name="stats_no_data_for_period">Ji bo vê heyamê dane tune</string>
     <string name="preference_strip_image_location">Ji medyayê cih rake</string>
     <string name="stats_cannot_be_started">Rêjejimar vêga nayên vekirin. Paştre dîsa biceribîne.</string>
-    <string name="giphy_powered_by_giphy">Bi piştevaniya GIPHYê</string>
-    <string name="giphy_picker_endless_scroll_network_error">Ji ber çewtiya girêdanê barkirina hinek medyayan biserneket.</string>
-    <string name="giphy_picker_empty_search_list">Lêgerîna te bi ti medyayan re hevber nebû</string>
-    <string name="giphy_picker_initial_empty_text">Ji bo tu GIFan tevlî PirtukxaneyaMedyayê bike, bigere!</string>
-    <string name="giphy_picker_search_hint">Li ser Giphyê bigere</string>
+    <string name="gif_powered_by_tenor">Bi piştevaniya TENORê</string>
+    <string name="gif_picker_endless_scroll_network_error">Ji ber çewtiya girêdanê barkirina hinek medyayan biserneket.</string>
+    <string name="gif_picker_empty_search_list">Lêgerîna te bi ti medyayan re hevber nebû</string>
+    <string name="gif_picker_initial_empty_text">Ji bo tu GIFan tevlî PirtukxaneyaMedyayê bike, bigere!</string>
+    <string name="gif_picker_search_hint">Li ser Tenorê bigere</string>
     <string name="stats_author_views_label">Dîtin</string>
     <string name="stats_author_label">Nivîskar</string>
     <string name="stats_authors">Nivîskar</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -316,11 +316,6 @@ Language: ku_TR
     <string name="stats_no_data_for_period">Ji bo vê heyamê dane tune</string>
     <string name="preference_strip_image_location">Ji medyayê cih rake</string>
     <string name="stats_cannot_be_started">Rêjejimar vêga nayên vekirin. Paştre dîsa biceribîne.</string>
-    <string name="gif_powered_by_tenor">Bi piştevaniya TENORê</string>
-    <string name="gif_picker_endless_scroll_network_error">Ji ber çewtiya girêdanê barkirina hinek medyayan biserneket.</string>
-    <string name="gif_picker_empty_search_list">Lêgerîna te bi ti medyayan re hevber nebû</string>
-    <string name="gif_picker_initial_empty_text">Ji bo tu GIFan tevlî PirtukxaneyaMedyayê bike, bigere!</string>
-    <string name="gif_picker_search_hint">Li ser Tenorê bigere</string>
     <string name="stats_author_views_label">Dîtin</string>
     <string name="stats_author_label">Nivîskar</string>
     <string name="stats_authors">Nivîskar</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -542,11 +542,11 @@ Language: ko_KR
     <string name="stats_no_data_for_period">이 기간에 데이터 없음</string>
     <string name="preference_strip_image_location">미디어에서 위치 제거</string>
     <string name="stats_cannot_be_started">지금은 통계를 열 수 없습니다. 나중에 다시 시도해 주세요.</string>
-    <string name="giphy_powered_by_giphy">GIPHY 제공</string>
-    <string name="giphy_picker_endless_scroll_network_error">네트워크 오류로 인해 일부 미디어를 로드하지 못했습니다.</string>
-    <string name="giphy_picker_empty_search_list">검색과 일치하는 미디어 없음</string>
-    <string name="giphy_picker_initial_empty_text">GIF를 검색하여 미디어 라이브러리에 추가하세요!</string>
-    <string name="giphy_picker_search_hint">Giphy 검색</string>
+    <string name="gif_powered_by_tenor">TENOR 제공</string>
+    <string name="gif_picker_endless_scroll_network_error">네트워크 오류로 인해 일부 미디어를 로드하지 못했습니다.</string>
+    <string name="gif_picker_empty_search_list">검색과 일치하는 미디어 없음</string>
+    <string name="gif_picker_initial_empty_text">GIF를 검색하여 미디어 라이브러리에 추가하세요!</string>
+    <string name="gif_picker_search_hint">Tenor 검색</string>
     <string name="stats_author_views_label">조회수</string>
     <string name="stats_author_label">글쓴이</string>
     <string name="stats_authors">글쓴이</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -542,11 +542,6 @@ Language: ko_KR
     <string name="stats_no_data_for_period">이 기간에 데이터 없음</string>
     <string name="preference_strip_image_location">미디어에서 위치 제거</string>
     <string name="stats_cannot_be_started">지금은 통계를 열 수 없습니다. 나중에 다시 시도해 주세요.</string>
-    <string name="gif_powered_by_tenor">TENOR 제공</string>
-    <string name="gif_picker_endless_scroll_network_error">네트워크 오류로 인해 일부 미디어를 로드하지 못했습니다.</string>
-    <string name="gif_picker_empty_search_list">검색과 일치하는 미디어 없음</string>
-    <string name="gif_picker_initial_empty_text">GIF를 검색하여 미디어 라이브러리에 추가하세요!</string>
-    <string name="gif_picker_search_hint">Tenor 검색</string>
     <string name="stats_author_views_label">조회수</string>
     <string name="stats_author_label">글쓴이</string>
     <string name="stats_authors">글쓴이</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -481,11 +481,11 @@ Language: nb_NO
     <string name="stats_no_data_for_period">Ingen data for denne perioden</string>
     <string name="preference_strip_image_location">Fjern dette stedet fra media</string>
     <string name="stats_cannot_be_started">Vi kan ikke åpne statistikken i øyeblikket. Vennligst prøv igjen senere</string>
-    <string name="giphy_powered_by_giphy">Drevet av GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Noe media kunne ikke lastes på grunn av en nettverksfeil.</string>
-    <string name="giphy_picker_empty_search_list">Ingen media passet ditt søk</string>
-    <string name="giphy_picker_initial_empty_text">Søk for å finne GIF-er å legge til i ditt mediebibliotek!</string>
-    <string name="giphy_picker_search_hint">Søk Giphy</string>
+    <string name="gif_powered_by_tenor">Drevet av TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Noe media kunne ikke lastes på grunn av en nettverksfeil.</string>
+    <string name="gif_picker_empty_search_list">Ingen media passet ditt søk</string>
+    <string name="gif_picker_initial_empty_text">Søk for å finne GIF-er å legge til i ditt mediebibliotek!</string>
+    <string name="gif_picker_search_hint">Søk Tenor</string>
     <string name="stats_author_views_label">Visninger</string>
     <string name="stats_author_label">Forfatter</string>
     <string name="stats_authors">Forfattere</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -481,11 +481,6 @@ Language: nb_NO
     <string name="stats_no_data_for_period">Ingen data for denne perioden</string>
     <string name="preference_strip_image_location">Fjern dette stedet fra media</string>
     <string name="stats_cannot_be_started">Vi kan ikke åpne statistikken i øyeblikket. Vennligst prøv igjen senere</string>
-    <string name="gif_powered_by_tenor">Drevet av TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Noe media kunne ikke lastes på grunn av en nettverksfeil.</string>
-    <string name="gif_picker_empty_search_list">Ingen media passet ditt søk</string>
-    <string name="gif_picker_initial_empty_text">Søk for å finne GIF-er å legge til i ditt mediebibliotek!</string>
-    <string name="gif_picker_search_hint">Søk Tenor</string>
     <string name="stats_author_views_label">Visninger</string>
     <string name="stats_author_label">Forfatter</string>
     <string name="stats_authors">Forfattere</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -504,8 +504,6 @@ Language: nl
     <string name="stats_no_data_for_period">Geen gegevens voor deze periode</string>
     <string name="preference_strip_image_location">Locatie van media verwijderen</string>
     <string name="stats_cannot_be_started">We kunnen de statistieken momenteel niet openen. Probeer het later opnieuw</string>
-    <string name="gif_powered_by_tenor">Mogelijk gemaakt door TENOR</string>
-    <string name="gif_picker_search_hint">Zoek op Tenor</string>
     <string name="stats_author_label">Auteur</string>
     <string name="stats_authors">Auteurs</string>
     <string name="stats_search_terms_label">Zoekterm</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -504,8 +504,8 @@ Language: nl
     <string name="stats_no_data_for_period">Geen gegevens voor deze periode</string>
     <string name="preference_strip_image_location">Locatie van media verwijderen</string>
     <string name="stats_cannot_be_started">We kunnen de statistieken momenteel niet openen. Probeer het later opnieuw</string>
-    <string name="giphy_powered_by_giphy">Mogelijk gemaakt door GIPHY</string>
-    <string name="giphy_picker_search_hint">Zoek op Giphy</string>
+    <string name="gif_powered_by_tenor">Mogelijk gemaakt door TENOR</string>
+    <string name="gif_picker_search_hint">Zoek op Tenor</string>
     <string name="stats_author_label">Auteur</string>
     <string name="stats_authors">Auteurs</string>
     <string name="stats_search_terms_label">Zoekterm</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -493,11 +493,11 @@ Language: pl
     <string name="stats_no_data_for_period">Brak danych dla tego okresu</string>
     <string name="preference_strip_image_location">Usuń lokalizację GPS z plików mediów</string>
     <string name="stats_cannot_be_started">Nie możemy w tym momencie otworzyć statystyk. Spróbuj ponownie później</string>
-    <string name="giphy_powered_by_giphy">Wspierane przez GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Niektórych plików mediów nie udało się przesłać z powodu błędu sieci. </string>
-    <string name="giphy_picker_empty_search_list">Brak plików mediów dopasowanych do twojego zapytania</string>
-    <string name="giphy_picker_initial_empty_text">Przeszukaj aby znaleźć pliki GIF które możesz dodać do swojej biblioteki mediów!</string>
-    <string name="giphy_picker_search_hint">Przeszukaj Giphy</string>
+    <string name="gif_powered_by_tenor">Wspierane przez TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Niektórych plików mediów nie udało się przesłać z powodu błędu sieci. </string>
+    <string name="gif_picker_empty_search_list">Brak plików mediów dopasowanych do twojego zapytania</string>
+    <string name="gif_picker_initial_empty_text">Przeszukaj aby znaleźć pliki GIF które możesz dodać do swojej biblioteki mediów!</string>
+    <string name="gif_picker_search_hint">Przeszukaj Tenor</string>
     <string name="stats_author_views_label">Wyświetleń</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autorzy</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -493,11 +493,6 @@ Language: pl
     <string name="stats_no_data_for_period">Brak danych dla tego okresu</string>
     <string name="preference_strip_image_location">Usuń lokalizację GPS z plików mediów</string>
     <string name="stats_cannot_be_started">Nie możemy w tym momencie otworzyć statystyk. Spróbuj ponownie później</string>
-    <string name="gif_powered_by_tenor">Wspierane przez TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Niektórych plików mediów nie udało się przesłać z powodu błędu sieci. </string>
-    <string name="gif_picker_empty_search_list">Brak plików mediów dopasowanych do twojego zapytania</string>
-    <string name="gif_picker_initial_empty_text">Przeszukaj aby znaleźć pliki GIF które możesz dodać do swojej biblioteki mediów!</string>
-    <string name="gif_picker_search_hint">Przeszukaj Tenor</string>
     <string name="stats_author_views_label">Wyświetleń</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autorzy</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -545,11 +545,11 @@ Language: pt_BR
     <string name="stats_no_data_for_period">Nenhum dado para esse período</string>
     <string name="preference_strip_image_location">Remover localização de mídia</string>
     <string name="stats_cannot_be_started">Não conseguimos abrir as estatísticas agora. Tente novamente mais tarde.</string>
-    <string name="giphy_powered_by_giphy">Oferecido pelo GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Alguns arquivos não puderam ser carregados devido a problemas com a conexão.</string>
-    <string name="giphy_picker_empty_search_list">Nenhuma mídia corresponde à sua pesquisa</string>
-    <string name="giphy_picker_initial_empty_text">Pesquise para encontrar gifs para adicionar à sua biblioteca de mídias.</string>
-    <string name="giphy_picker_search_hint">Pesquisar no Giphy</string>
+    <string name="gif_powered_by_tenor">Oferecido pelo TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Alguns arquivos não puderam ser carregados devido a problemas com a conexão.</string>
+    <string name="gif_picker_empty_search_list">Nenhuma mídia corresponde à sua pesquisa</string>
+    <string name="gif_picker_initial_empty_text">Pesquise para encontrar gifs para adicionar à sua biblioteca de mídias.</string>
+    <string name="gif_picker_search_hint">Pesquisar no Tenor</string>
     <string name="stats_author_views_label">Visualizações</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -545,11 +545,6 @@ Language: pt_BR
     <string name="stats_no_data_for_period">Nenhum dado para esse período</string>
     <string name="preference_strip_image_location">Remover localização de mídia</string>
     <string name="stats_cannot_be_started">Não conseguimos abrir as estatísticas agora. Tente novamente mais tarde.</string>
-    <string name="gif_powered_by_tenor">Oferecido pelo TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Alguns arquivos não puderam ser carregados devido a problemas com a conexão.</string>
-    <string name="gif_picker_empty_search_list">Nenhuma mídia corresponde à sua pesquisa</string>
-    <string name="gif_picker_initial_empty_text">Pesquise para encontrar gifs para adicionar à sua biblioteca de mídias.</string>
-    <string name="gif_picker_search_hint">Pesquisar no Tenor</string>
     <string name="stats_author_views_label">Visualizações</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autores</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -554,11 +554,11 @@ Language: ro
     <string name="stats_no_data_for_period">Nu există date pentru această perioadă</string>
     <string name="preference_strip_image_location">Înlătură locația din Media</string>
     <string name="stats_cannot_be_started">Pentru moment, nu putem deschide statisticile. Te rog reîncearcă mai târziu</string>
-    <string name="giphy_powered_by_giphy">Propulsat de GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Unele elemente media au eșuat la încărcare din cauza unei erori de rețea.</string>
-    <string name="giphy_picker_empty_search_list">Nu s-a potrivit niciun element media cu căutarea ta</string>
-    <string name="giphy_picker_initial_empty_text">Caută pentru a găsi imagini GIF pe care să le adaugi în Biblioteca ta media!</string>
-    <string name="giphy_picker_search_hint">Caută cu Giphy</string>
+    <string name="gif_powered_by_tenor">Propulsat de TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Unele elemente media au eșuat la încărcare din cauza unei erori de rețea.</string>
+    <string name="gif_picker_empty_search_list">Nu s-a potrivit niciun element media cu căutarea ta</string>
+    <string name="gif_picker_initial_empty_text">Caută pentru a găsi imagini GIF pe care să le adaugi în Biblioteca ta media!</string>
+    <string name="gif_picker_search_hint">Caută cu Tenor</string>
     <string name="stats_author_views_label">Vizualizări</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autori</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -554,11 +554,6 @@ Language: ro
     <string name="stats_no_data_for_period">Nu există date pentru această perioadă</string>
     <string name="preference_strip_image_location">Înlătură locația din Media</string>
     <string name="stats_cannot_be_started">Pentru moment, nu putem deschide statisticile. Te rog reîncearcă mai târziu</string>
-    <string name="gif_powered_by_tenor">Propulsat de TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Unele elemente media au eșuat la încărcare din cauza unei erori de rețea.</string>
-    <string name="gif_picker_empty_search_list">Nu s-a potrivit niciun element media cu căutarea ta</string>
-    <string name="gif_picker_initial_empty_text">Caută pentru a găsi imagini GIF pe care să le adaugi în Biblioteca ta media!</string>
-    <string name="gif_picker_search_hint">Caută cu Tenor</string>
     <string name="stats_author_views_label">Vizualizări</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autori</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -554,11 +554,11 @@ Language: ru
     <string name="stats_no_data_for_period">Для указанного периода нет данных</string>
     <string name="preference_strip_image_location">Убрать данные местоположения из медиафайлов</string>
     <string name="stats_cannot_be_started">Извините, статистика в данный момент недоступна, попробуйте позже.</string>
-    <string name="giphy_powered_by_giphy">Работает с GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Некоторые медиафайлы не загрузились из-за ошибки сети.</string>
-    <string name="giphy_picker_empty_search_list">Мультимедиа по критериям поиска не найдены</string>
-    <string name="giphy_picker_initial_empty_text">Найдите GIF изображения и добавьте их в медиатеку!</string>
-    <string name="giphy_picker_search_hint">Поиск в Giphy</string>
+    <string name="gif_powered_by_tenor">Работает с TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Некоторые медиафайлы не загрузились из-за ошибки сети.</string>
+    <string name="gif_picker_empty_search_list">Мультимедиа по критериям поиска не найдены</string>
+    <string name="gif_picker_initial_empty_text">Найдите GIF изображения и добавьте их в медиатеку!</string>
+    <string name="gif_picker_search_hint">Поиск в Tenor</string>
     <string name="stats_author_views_label">Просмотры</string>
     <string name="stats_author_label">Автор</string>
     <string name="stats_authors">Авторы</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -554,11 +554,6 @@ Language: ru
     <string name="stats_no_data_for_period">Для указанного периода нет данных</string>
     <string name="preference_strip_image_location">Убрать данные местоположения из медиафайлов</string>
     <string name="stats_cannot_be_started">Извините, статистика в данный момент недоступна, попробуйте позже.</string>
-    <string name="gif_powered_by_tenor">Работает с TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Некоторые медиафайлы не загрузились из-за ошибки сети.</string>
-    <string name="gif_picker_empty_search_list">Мультимедиа по критериям поиска не найдены</string>
-    <string name="gif_picker_initial_empty_text">Найдите GIF изображения и добавьте их в медиатеку!</string>
-    <string name="gif_picker_search_hint">Поиск в Tenor</string>
     <string name="stats_author_views_label">Просмотры</string>
     <string name="stats_author_label">Автор</string>
     <string name="stats_authors">Авторы</string>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -52,8 +52,6 @@ Language: sk
     <string name="snackbar_conflict_undo">Vrátiť späť</string>
     <string name="stats_no_data_for_period">Žiadne dáta pre toto obdobie</string>
     <string name="preference_strip_image_location">Odstrániť lokáciu z médiá</string>
-    <string name="gif_powered_by_tenor">Poháňa TENOR</string>
-    <string name="gif_picker_search_hint">Vyhľadať v Tenor</string>
     <string name="stats_author_views_label">Zobrazenia</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autori</string>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -52,8 +52,8 @@ Language: sk
     <string name="snackbar_conflict_undo">Vrátiť späť</string>
     <string name="stats_no_data_for_period">Žiadne dáta pre toto obdobie</string>
     <string name="preference_strip_image_location">Odstrániť lokáciu z médiá</string>
-    <string name="giphy_powered_by_giphy">Poháňa GIPHY</string>
-    <string name="giphy_picker_search_hint">Vyhľadať v Giphy</string>
+    <string name="gif_powered_by_tenor">Poháňa TENOR</string>
+    <string name="gif_picker_search_hint">Vyhľadať v Tenor</string>
     <string name="stats_author_views_label">Zobrazenia</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autori</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -554,11 +554,11 @@ Language: sq_AL
     <string name="stats_no_data_for_period">S’ka të dhëna për këtë periudhë</string>
     <string name="preference_strip_image_location">Hiqe vendndodhjen prej mediash</string>
     <string name="stats_cannot_be_started">S’i hapim dot statistikat tani. Ju lutemi, riprovoni më vonë</string>
-    <string name="giphy_powered_by_giphy">Bazuar në Giphy</string>
-    <string name="giphy_picker_endless_scroll_network_error">Dështoi ngarkimi për ca media, për shkak të një gabimi rrjeti.</string>
-    <string name="giphy_picker_empty_search_list">S’ka media që përputhet me kërkimin tuaj</string>
-    <string name="giphy_picker_initial_empty_text">Kërkoni për të gjetur GIF-e që t’i shtoni te Mediateka juaj!</string>
-    <string name="giphy_picker_search_hint">Kërkoni në Giphy</string>
+    <string name="gif_powered_by_tenor">Bazuar në Tenor</string>
+    <string name="gif_picker_endless_scroll_network_error">Dështoi ngarkimi për ca media, për shkak të një gabimi rrjeti.</string>
+    <string name="gif_picker_empty_search_list">S’ka media që përputhet me kërkimin tuaj</string>
+    <string name="gif_picker_initial_empty_text">Kërkoni për të gjetur GIF-e që t’i shtoni te Mediateka juaj!</string>
+    <string name="gif_picker_search_hint">Kërkoni në Tenor</string>
     <string name="stats_author_views_label">Parje</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autorë</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -554,11 +554,6 @@ Language: sq_AL
     <string name="stats_no_data_for_period">S’ka të dhëna për këtë periudhë</string>
     <string name="preference_strip_image_location">Hiqe vendndodhjen prej mediash</string>
     <string name="stats_cannot_be_started">S’i hapim dot statistikat tani. Ju lutemi, riprovoni më vonë</string>
-    <string name="gif_powered_by_tenor">Bazuar në Tenor</string>
-    <string name="gif_picker_endless_scroll_network_error">Dështoi ngarkimi për ca media, për shkak të një gabimi rrjeti.</string>
-    <string name="gif_picker_empty_search_list">S’ka media që përputhet me kërkimin tuaj</string>
-    <string name="gif_picker_initial_empty_text">Kërkoni për të gjetur GIF-e që t’i shtoni te Mediateka juaj!</string>
-    <string name="gif_picker_search_hint">Kërkoni në Tenor</string>
     <string name="stats_author_views_label">Parje</string>
     <string name="stats_author_label">Autor</string>
     <string name="stats_authors">Autorë</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -554,11 +554,11 @@ Language: sv_SE
     <string name="stats_no_data_for_period">Inga uppgifter för denna tidsperiod</string>
     <string name="preference_strip_image_location">Avlägsna position från media</string>
     <string name="stats_cannot_be_started">Just nu går det inte att öppna statistiken. Försök igen senare</string>
-    <string name="giphy_powered_by_giphy">Drivs med hjälp av GIPHY</string>
-    <string name="giphy_picker_endless_scroll_network_error">Vissa mediefiler kunde inte laddas på grund av nätverksproblem.</string>
-    <string name="giphy_picker_empty_search_list">Inga media matchar din sökning</string>
-    <string name="giphy_picker_initial_empty_text">Leta efter GIF-filer du kan lägga till i ditt mediebibliotek!</string>
-    <string name="giphy_picker_search_hint">Sök i Giphy</string>
+    <string name="gif_powered_by_tenor">Drivs med hjälp av TENOR</string>
+    <string name="gif_picker_endless_scroll_network_error">Vissa mediefiler kunde inte laddas på grund av nätverksproblem.</string>
+    <string name="gif_picker_empty_search_list">Inga media matchar din sökning</string>
+    <string name="gif_picker_initial_empty_text">Leta efter GIF-filer du kan lägga till i ditt mediebibliotek!</string>
+    <string name="gif_picker_search_hint">Sök i Tenor</string>
     <string name="stats_author_views_label">Visningar</string>
     <string name="stats_author_label">Författare</string>
     <string name="stats_authors">Författare</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -554,11 +554,6 @@ Language: sv_SE
     <string name="stats_no_data_for_period">Inga uppgifter för denna tidsperiod</string>
     <string name="preference_strip_image_location">Avlägsna position från media</string>
     <string name="stats_cannot_be_started">Just nu går det inte att öppna statistiken. Försök igen senare</string>
-    <string name="gif_powered_by_tenor">Drivs med hjälp av TENOR</string>
-    <string name="gif_picker_endless_scroll_network_error">Vissa mediefiler kunde inte laddas på grund av nätverksproblem.</string>
-    <string name="gif_picker_empty_search_list">Inga media matchar din sökning</string>
-    <string name="gif_picker_initial_empty_text">Leta efter GIF-filer du kan lägga till i ditt mediebibliotek!</string>
-    <string name="gif_picker_search_hint">Sök i Tenor</string>
     <string name="stats_author_views_label">Visningar</string>
     <string name="stats_author_label">Författare</string>
     <string name="stats_authors">Författare</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -554,11 +554,11 @@ Language: tr
     <string name="stats_no_data_for_period">Bu dönem için veri yok</string>
     <string name="preference_strip_image_location">Ortam dosyasından konum bilgisini kaldır</string>
     <string name="stats_cannot_be_started">Şu anda istatistikleri açamıyoruz. Lütfen daha sonra tekrar deneyiniz.</string>
-    <string name="giphy_powered_by_giphy">GIPHY tarafından sağlanır</string>
-    <string name="giphy_picker_endless_scroll_network_error">Ağ hatası nedeniyle bazı ortam dosyaları yüklenemedi.</string>
-    <string name="giphy_picker_empty_search_list">Aramanızla eşleşen bir ortam yok</string>
-    <string name="giphy_picker_initial_empty_text">Ortam kütüphanenize GIF bulup eklemek için arayın!</string>
-    <string name="giphy_picker_search_hint">Giphy\'de ara</string>
+    <string name="gif_powered_by_tenor">TENOR tarafından sağlanır</string>
+    <string name="gif_picker_endless_scroll_network_error">Ağ hatası nedeniyle bazı ortam dosyaları yüklenemedi.</string>
+    <string name="gif_picker_empty_search_list">Aramanızla eşleşen bir ortam yok</string>
+    <string name="gif_picker_initial_empty_text">Ortam kütüphanenize GIF bulup eklemek için arayın!</string>
+    <string name="gif_picker_search_hint">Tenor\'de ara</string>
     <string name="stats_author_views_label">Görüntülemeler</string>
     <string name="stats_author_label">Yazar</string>
     <string name="stats_authors">Yazarlar</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -554,11 +554,6 @@ Language: tr
     <string name="stats_no_data_for_period">Bu dönem için veri yok</string>
     <string name="preference_strip_image_location">Ortam dosyasından konum bilgisini kaldır</string>
     <string name="stats_cannot_be_started">Şu anda istatistikleri açamıyoruz. Lütfen daha sonra tekrar deneyiniz.</string>
-    <string name="gif_powered_by_tenor">TENOR tarafından sağlanır</string>
-    <string name="gif_picker_endless_scroll_network_error">Ağ hatası nedeniyle bazı ortam dosyaları yüklenemedi.</string>
-    <string name="gif_picker_empty_search_list">Aramanızla eşleşen bir ortam yok</string>
-    <string name="gif_picker_initial_empty_text">Ortam kütüphanenize GIF bulup eklemek için arayın!</string>
-    <string name="gif_picker_search_hint">Tenor\'de ara</string>
     <string name="stats_author_views_label">Görüntülemeler</string>
     <string name="stats_author_label">Yazar</string>
     <string name="stats_authors">Yazarlar</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -497,11 +497,6 @@ Language: zh_CN
     <string name="stats_no_data_for_period">没有此时间段的数据</string>
     <string name="preference_strip_image_location">从媒体删除位置信息</string>
     <string name="stats_cannot_be_started">我们现在无法打开统计信息。请稍后重试</string>
-    <string name="gif_powered_by_tenor">由 TENOR 提供支持</string>
-    <string name="gif_picker_endless_scroll_network_error">由于网络错误，无法加载某些媒体。</string>
-    <string name="gif_picker_empty_search_list">没有与您的搜索匹配的媒体</string>
-    <string name="gif_picker_initial_empty_text">搜索查找要添加到您的媒体库中的 GIF！</string>
-    <string name="gif_picker_search_hint">搜索 Tenor</string>
     <string name="stats_author_views_label">浏览量</string>
     <string name="stats_author_label">作者</string>
     <string name="stats_authors">作者</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -497,11 +497,11 @@ Language: zh_CN
     <string name="stats_no_data_for_period">没有此时间段的数据</string>
     <string name="preference_strip_image_location">从媒体删除位置信息</string>
     <string name="stats_cannot_be_started">我们现在无法打开统计信息。请稍后重试</string>
-    <string name="giphy_powered_by_giphy">由 GIPHY 提供支持</string>
-    <string name="giphy_picker_endless_scroll_network_error">由于网络错误，无法加载某些媒体。</string>
-    <string name="giphy_picker_empty_search_list">没有与您的搜索匹配的媒体</string>
-    <string name="giphy_picker_initial_empty_text">搜索查找要添加到您的媒体库中的 GIF！</string>
-    <string name="giphy_picker_search_hint">搜索 Giphy</string>
+    <string name="gif_powered_by_tenor">由 TENOR 提供支持</string>
+    <string name="gif_picker_endless_scroll_network_error">由于网络错误，无法加载某些媒体。</string>
+    <string name="gif_picker_empty_search_list">没有与您的搜索匹配的媒体</string>
+    <string name="gif_picker_initial_empty_text">搜索查找要添加到您的媒体库中的 GIF！</string>
+    <string name="gif_picker_search_hint">搜索 Tenor</string>
     <string name="stats_author_views_label">浏览量</string>
     <string name="stats_author_label">作者</string>
     <string name="stats_authors">作者</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -545,11 +545,6 @@ Language: zh_TW
     <string name="stats_no_data_for_period">此期間沒有資料</string>
     <string name="preference_strip_image_location">從媒體移除位置資訊</string>
     <string name="stats_cannot_be_started">目前我們無法開啟統計資料。請稍後再試一次</string>
-    <string name="gif_powered_by_tenor">由 TENOR 建置</string>
-    <string name="gif_picker_endless_scroll_network_error">網路發生錯誤，導致部份媒體載入失敗。</string>
-    <string name="gif_picker_empty_search_list">沒有符合你搜尋條件的媒體</string>
-    <string name="gif_picker_initial_empty_text">搜尋免費 GIF 以新增至你的媒體庫！</string>
-    <string name="gif_picker_search_hint">搜尋 Tenor</string>
     <string name="stats_author_views_label">瀏覽數</string>
     <string name="stats_author_label">作者</string>
     <string name="stats_authors">作者</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -545,11 +545,11 @@ Language: zh_TW
     <string name="stats_no_data_for_period">此期間沒有資料</string>
     <string name="preference_strip_image_location">從媒體移除位置資訊</string>
     <string name="stats_cannot_be_started">目前我們無法開啟統計資料。請稍後再試一次</string>
-    <string name="giphy_powered_by_giphy">由 GIPHY 建置</string>
-    <string name="giphy_picker_endless_scroll_network_error">網路發生錯誤，導致部份媒體載入失敗。</string>
-    <string name="giphy_picker_empty_search_list">沒有符合你搜尋條件的媒體</string>
-    <string name="giphy_picker_initial_empty_text">搜尋免費 GIF 以新增至你的媒體庫！</string>
-    <string name="giphy_picker_search_hint">搜尋 Giphy</string>
+    <string name="gif_powered_by_tenor">由 TENOR 建置</string>
+    <string name="gif_picker_endless_scroll_network_error">網路發生錯誤，導致部份媒體載入失敗。</string>
+    <string name="gif_picker_empty_search_list">沒有符合你搜尋條件的媒體</string>
+    <string name="gif_picker_initial_empty_text">搜尋免費 GIF 以新增至你的媒體庫！</string>
+    <string name="gif_picker_search_hint">搜尋 Tenor</string>
     <string name="stats_author_views_label">瀏覽數</string>
     <string name="stats_author_label">作者</string>
     <string name="stats_authors">作者</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -545,11 +545,6 @@ Language: zh_TW
     <string name="stats_no_data_for_period">此期間沒有資料</string>
     <string name="preference_strip_image_location">從媒體移除位置資訊</string>
     <string name="stats_cannot_be_started">目前我們無法開啟統計資料。請稍後再試一次</string>
-    <string name="gif_powered_by_tenor">由 TENOR 建置</string>
-    <string name="gif_picker_endless_scroll_network_error">網路發生錯誤，導致部份媒體載入失敗。</string>
-    <string name="gif_picker_empty_search_list">沒有符合你搜尋條件的媒體</string>
-    <string name="gif_picker_initial_empty_text">搜尋免費 GIF 以新增至你的媒體庫！</string>
-    <string name="gif_picker_search_hint">搜尋 Tenor</string>
     <string name="stats_author_views_label">瀏覽數</string>
     <string name="stats_author_label">作者</string>
     <string name="stats_authors">作者</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -545,11 +545,11 @@ Language: zh_TW
     <string name="stats_no_data_for_period">此期間沒有資料</string>
     <string name="preference_strip_image_location">從媒體移除位置資訊</string>
     <string name="stats_cannot_be_started">目前我們無法開啟統計資料。請稍後再試一次</string>
-    <string name="giphy_powered_by_giphy">由 GIPHY 建置</string>
-    <string name="giphy_picker_endless_scroll_network_error">網路發生錯誤，導致部份媒體載入失敗。</string>
-    <string name="giphy_picker_empty_search_list">沒有符合你搜尋條件的媒體</string>
-    <string name="giphy_picker_initial_empty_text">搜尋免費 GIF 以新增至你的媒體庫！</string>
-    <string name="giphy_picker_search_hint">搜尋 Giphy</string>
+    <string name="gif_powered_by_tenor">由 TENOR 建置</string>
+    <string name="gif_picker_endless_scroll_network_error">網路發生錯誤，導致部份媒體載入失敗。</string>
+    <string name="gif_picker_empty_search_list">沒有符合你搜尋條件的媒體</string>
+    <string name="gif_picker_initial_empty_text">搜尋免費 GIF 以新增至你的媒體庫！</string>
+    <string name="gif_picker_search_hint">搜尋 Tenor</string>
     <string name="stats_author_views_label">瀏覽數</string>
     <string name="stats_author_label">作者</string>
     <string name="stats_authors">作者</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2235,12 +2235,12 @@
     <string name="stock_media_picker_initial_empty_subtext">Photos provided by %s</string>
 
     <!-- GIFs -->
-    <string name="giphy_picker_search_hint">Search Tenor</string>
-    <string name="giphy_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
-    <string name="giphy_picker_empty_search_list">No media matching your search</string>
-    <string name="giphy_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
-    <string name="gifs_list_search_returned_unknown_error">Sorry, there was a problem</string>
-    <string name="giphy_powered_by_giphy">Powered by Tenor</string>
+    <string name="gif_picker_search_hint">Search Tenor</string>
+    <string name="gif_picker_initial_empty_text">Search to find GIFs to add to your Media Library!</string>
+    <string name="gif_picker_empty_search_list">No media matching your search</string>
+    <string name="gif_picker_endless_scroll_network_error">Some media failed to load due to a network error.</string>
+    <string name="gif_list_search_returned_unknown_error">Sorry, there was a problem</string>
+    <string name="gif_powered_by_tenor">Powered by Tenor</string>
 
     <!-- E-mail verification reminder dialog -->
     <string name="toast_saving_post_as_draft">Saving post as draft</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -121,7 +121,7 @@ class EditorMediaTest : BaseUnitTest() {
     }
 
     @Test
-    fun `addMediaFromGiphyToPostAsync invokes addLocalMediaToEditorAsync with all media`() = test {
+    fun `addGifMediaToPostAsync invokes addLocalMediaToEditorAsync with all media`() = test {
         // Arrange
         val localIdArray = listOf(1, 2, 3).toIntArray()
         val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase()
@@ -130,7 +130,7 @@ class EditorMediaTest : BaseUnitTest() {
         createEditorMedia(
                 addLocalMediaToPostUseCase = addLocalMediaToPostUseCase
         )
-                .addMediaFromGiphyToPostAsync(localIdArray)
+                .addGifMediaToPostAsync(localIdArray)
         // Assert
         verify(addLocalMediaToPostUseCase).addLocalMediaToEditorAsync(
                 eq(localIdArray.toList()),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceFixtures.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.viewmodel.gif
 
 import com.nhaarman.mockitokotlin2.mock
 
-object GiphyPickerDataSourceFixtures {
+object GifPickerDataSourceFixtures {
     internal val expectedGifMediaViewModelCollection: List<GifMediaViewModel> = listOf(
             mock(),
             mock(),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import androidx.paging.PositionalDataSource.LoadInitialCallback
 import androidx.paging.PositionalDataSource.LoadInitialParams
@@ -16,23 +16,23 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.wordpress.android.viewmodel.giphy.GiphyPickerDataSourceFixtures.expectedGifMediaViewModelCollection
-import org.wordpress.android.viewmodel.giphy.provider.GifProvider
-import org.wordpress.android.viewmodel.giphy.provider.GifProvider.GifRequestFailedException
+import org.wordpress.android.viewmodel.gif.GiphyPickerDataSourceFixtures.expectedGifMediaViewModelCollection
+import org.wordpress.android.viewmodel.gif.provider.GifProvider
+import org.wordpress.android.viewmodel.gif.provider.GifProvider.GifRequestFailedException
 
-class GiphyPickerDataSourceTest {
+class GifPickerDataSourceTest {
     @Mock lateinit var gifProvider: GifProvider
 
-    lateinit var onSuccessCaptor: KArgumentCaptor<(List<GiphyMediaViewModel>, Int?) -> Unit>
+    lateinit var onSuccessCaptor: KArgumentCaptor<(List<GifMediaViewModel>, Int?) -> Unit>
 
     lateinit var onFailureCaptor: KArgumentCaptor<(Throwable) -> Unit>
 
-    private lateinit var pickerDataSourceUnderTest: GiphyPickerDataSource
+    private lateinit var pickerDataSourceUnderTest: GifPickerDataSource
 
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        pickerDataSourceUnderTest = GiphyPickerDataSource(gifProvider, "test")
+        pickerDataSourceUnderTest = GifPickerDataSource(gifProvider, "test")
         onSuccessCaptor = argumentCaptor()
         onFailureCaptor = argumentCaptor()
     }
@@ -42,15 +42,15 @@ class GiphyPickerDataSourceTest {
         var onResultWasCalled = false
 
         val params = LoadInitialParams(0, 20, 5, false)
-        val dataSourceCallback = object : LoadInitialCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int, totalCount: Int) {
+        val dataSourceCallback = object : LoadInitialCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int, totalCount: Int) {
                 onResultWasCalled = true
                 assertThat(data).isEqualTo(expectedGifMediaViewModelCollection)
                 assertThat(position).isEqualTo(0)
                 assertThat(totalCount).isEqualTo(4)
             }
 
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int) {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int) {
                 fail("Wrong onResult called")
             }
         }
@@ -67,15 +67,15 @@ class GiphyPickerDataSourceTest {
         var onResultWasCalled = false
 
         val params = LoadInitialParams(0, 20, 5, false)
-        val dataSourceCallback = object : LoadInitialCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int, totalCount: Int) {
+        val dataSourceCallback = object : LoadInitialCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int, totalCount: Int) {
                 onResultWasCalled = true
                 assertThat(data).isEqualTo(expectedGifMediaViewModelCollection)
                 assertThat(position).isEqualTo(0)
                 assertThat(totalCount).isEqualTo(4)
             }
 
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int) {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int) {
                 fail("Wrong onResult called")
             }
         }
@@ -92,15 +92,15 @@ class GiphyPickerDataSourceTest {
         var onResultWasCalled = false
 
         val params = LoadInitialParams(0, 20, 5, false)
-        val dataSourceCallback = object : LoadInitialCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int, totalCount: Int) {
+        val dataSourceCallback = object : LoadInitialCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int, totalCount: Int) {
                 onResultWasCalled = true
                 assertThat(data).isEqualTo(expectedGifMediaViewModelCollection)
                 assertThat(position).isEqualTo(0)
                 assertThat(totalCount).isEqualTo(4)
             }
 
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int) {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int) {
                 fail("Wrong onResult called")
             }
         }
@@ -115,18 +115,18 @@ class GiphyPickerDataSourceTest {
     @Test
     fun `loadInitial should call onResult with emptyList when search query is blank`() {
         var onResultWasCalled = false
-        pickerDataSourceUnderTest = GiphyPickerDataSource(gifProvider, "")
+        pickerDataSourceUnderTest = GifPickerDataSource(gifProvider, "")
 
         val params = LoadInitialParams(0, 20, 5, false)
-        val dataSourceCallback = object : LoadInitialCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int, totalCount: Int) {
+        val dataSourceCallback = object : LoadInitialCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int, totalCount: Int) {
                 onResultWasCalled = true
                 assertThat(data).isEmpty()
                 assertThat(position).isEqualTo(0)
                 assertThat(totalCount).isEqualTo(0)
             }
 
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int) {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int) {
                 fail("Wrong onResult called")
             }
         }
@@ -142,15 +142,15 @@ class GiphyPickerDataSourceTest {
         val expectedThrowable = GifRequestFailedException("Test throwable")
 
         val params = LoadInitialParams(0, 20, 5, false)
-        val dataSourceCallback = object : LoadInitialCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int, totalCount: Int) {
+        val dataSourceCallback = object : LoadInitialCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int, totalCount: Int) {
                 onResultWasCalled = true
                 assertThat(data).isEmpty()
                 assertThat(position).isEqualTo(0)
                 assertThat(totalCount).isEqualTo(0)
             }
 
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int) {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int) {
                 fail("Wrong onResult called")
             }
         }
@@ -169,12 +169,12 @@ class GiphyPickerDataSourceTest {
         val expectedThrowable = GifRequestFailedException("Test throwable")
 
         val params = LoadInitialParams(0, 20, 5, false)
-        val dataSourceCallback = object : LoadInitialCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int, totalCount: Int) {
+        val dataSourceCallback = object : LoadInitialCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int, totalCount: Int) {
                 onResultWasCalled = true
             }
 
-            override fun onResult(data: MutableList<GiphyMediaViewModel>, position: Int) {
+            override fun onResult(data: MutableList<GifMediaViewModel>, position: Int) {
                 fail("Wrong onResult called")
             }
         }
@@ -195,8 +195,8 @@ class GiphyPickerDataSourceTest {
         var onResultWasCalled = false
 
         val params = LoadRangeParams(0, 20)
-        val dataSourceCallback = object: LoadRangeCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>) {
+        val dataSourceCallback = object: LoadRangeCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>) {
                 onResultWasCalled = true
                 assertThat(data).isEqualTo(expectedGifMediaViewModelCollection)
             }
@@ -214,8 +214,8 @@ class GiphyPickerDataSourceTest {
         val spiedDataSource = spy(pickerDataSourceUnderTest)
 
         val params = LoadRangeParams(0, 20)
-        val dataSourceCallback = object: LoadRangeCallback<GiphyMediaViewModel>() {
-            override fun onResult(data: MutableList<GiphyMediaViewModel>) {}
+        val dataSourceCallback = object: LoadRangeCallback<GifMediaViewModel>() {
+            override fun onResult(data: MutableList<GifMediaViewModel>) {}
         }
         spiedDataSource.loadRange(params, dataSourceCallback)
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerDataSourceTest.kt
@@ -16,7 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.wordpress.android.viewmodel.gif.GiphyPickerDataSourceFixtures.expectedGifMediaViewModelCollection
+import org.wordpress.android.viewmodel.gif.GifPickerDataSourceFixtures.expectedGifMediaViewModelCollection
 import org.wordpress.android.viewmodel.gif.provider.GifProvider
 import org.wordpress.android.viewmodel.gif.provider.GifProvider.GifRequestFailedException
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.paging.PositionalDataSource.LoadInitialCallback
@@ -20,27 +20,27 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel.EmptyDisplayMode
-import org.wordpress.android.viewmodel.giphy.GiphyPickerViewModel.State
+import org.wordpress.android.viewmodel.gif.GifPickerViewModel.EmptyDisplayMode
+import org.wordpress.android.viewmodel.gif.GifPickerViewModel.State
 import java.util.Random
 import java.util.UUID
 
 @RunWith(MockitoJUnitRunner::class)
-class GiphyPickerViewModelTest {
+class GifPickerViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
-    private lateinit var viewModel: GiphyPickerViewModel
+    private lateinit var viewModel: GifPickerViewModel
 
-    private val dataSourceFactory = mock<GiphyPickerDataSourceFactory>()
-    private val mediaFetcher = mock<GiphyMediaFetcher>()
+    private val dataSourceFactory = mock<GifPickerDataSourceFactory>()
+    private val mediaFetcher = mock<GifMediaFetcher>()
     private val analyticsTracker = mock<AnalyticsTrackerWrapper>()
 
     @Mock private lateinit var networkUtils: NetworkUtilsWrapper
 
     @Before
     fun setUp() {
-        viewModel = GiphyPickerViewModel(
+        viewModel = GifPickerViewModel(
                 dataSourceFactory = dataSourceFactory,
                 networkUtils = networkUtils,
                 mediaFetcher = mediaFetcher,
@@ -150,12 +150,12 @@ class GiphyPickerViewModelTest {
     @Test
     fun `when search results are empty, the empty view should be visible and says there are no results`() {
         // Arrange
-        val dataSource = mock<GiphyPickerDataSource>()
+        val dataSource = mock<GifPickerDataSource>()
 
         whenever(dataSourceFactory.create()).thenReturn(dataSource)
         whenever(dataSourceFactory.searchQuery).thenReturn("dummy")
 
-        val callbackCaptor = argumentCaptor<LoadInitialCallback<GiphyMediaViewModel>>()
+        val callbackCaptor = argumentCaptor<LoadInitialCallback<GifMediaViewModel>>()
         doNothing().whenever(dataSource).loadInitial(any(), callbackCaptor.capture())
 
         // Observe mediaViewModelPagedList so the DataSourceFactory will be activated and perform API requests
@@ -177,12 +177,12 @@ class GiphyPickerViewModelTest {
     @Test
     fun `when the initial load fails, the empty view should show a network error`() {
         // Arrange
-        val dataSource = mock<GiphyPickerDataSource>()
+        val dataSource = mock<GifPickerDataSource>()
 
         whenever(dataSourceFactory.create()).thenReturn(dataSource)
         whenever(dataSourceFactory.initialLoadError).thenReturn(mock())
 
-        val callbackCaptor = argumentCaptor<LoadInitialCallback<GiphyMediaViewModel>>()
+        val callbackCaptor = argumentCaptor<LoadInitialCallback<GifMediaViewModel>>()
         doNothing().whenever(dataSource).loadInitial(any(), callbackCaptor.capture())
 
         // Observe mediaViewModelPagedList so the DataSourceFactory will be activated and perform API requests
@@ -316,7 +316,7 @@ class GiphyPickerViewModelTest {
         id = Random().nextInt()
     }
 
-    private fun createGiphyMediaViewModel() = MutableGiphyMediaViewModel(
+    private fun createGiphyMediaViewModel() = MutableGifMediaViewModel(
             id = UUID.randomUUID().toString(),
             thumbnailUri = mock(),
             largeImageUri = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GifPickerViewModelTest.kt
@@ -52,7 +52,7 @@ class GifPickerViewModelTest {
 
     @Test
     fun `when setting a mediaViewModel as selected, it adds that to the selected list`() {
-        val mediaViewModel = createGiphyMediaViewModel()
+        val mediaViewModel = createGifMediaViewModel()
 
         viewModel.toggleSelected(mediaViewModel)
 
@@ -64,7 +64,7 @@ class GifPickerViewModelTest {
 
     @Test
     fun `when setting a mediaViewModel as selected, it updates the isSelected and selectedNumber`() {
-        val mediaViewModel = createGiphyMediaViewModel()
+        val mediaViewModel = createGifMediaViewModel()
 
         viewModel.toggleSelected(mediaViewModel)
 
@@ -75,7 +75,7 @@ class GifPickerViewModelTest {
     @Test
     fun `when toggling an already selected mediaViewModel, it gets deselected and removed from the selected list`() {
         // Arrange
-        val mediaViewModel = createGiphyMediaViewModel()
+        val mediaViewModel = createGifMediaViewModel()
         viewModel.toggleSelected(mediaViewModel)
 
         // Act
@@ -91,10 +91,10 @@ class GifPickerViewModelTest {
     @Test
     fun `when deselecting a mediaViewModel, it rebuilds the selectedNumbers so they are continuous`() {
         // Arrange
-        val alpha = createGiphyMediaViewModel()
-        val bravo = createGiphyMediaViewModel()
-        val charlie = createGiphyMediaViewModel()
-        val delta = createGiphyMediaViewModel()
+        val alpha = createGifMediaViewModel()
+        val bravo = createGifMediaViewModel()
+        val charlie = createGifMediaViewModel()
+        val delta = createGifMediaViewModel()
 
         listOf(alpha, bravo, charlie, delta).forEach(viewModel::toggleSelected)
 
@@ -121,7 +121,7 @@ class GifPickerViewModelTest {
     @Test
     fun `when the searchQuery is changed, it clears the selected mediaViewModel list`() {
         // Arrange
-        val mediaViewModel = createGiphyMediaViewModel()
+        val mediaViewModel = createGifMediaViewModel()
         viewModel.toggleSelected(mediaViewModel)
 
         // Act
@@ -287,7 +287,7 @@ class GifPickerViewModelTest {
         }
         check(viewModel.state.value == State.FINISHED)
 
-        viewModel.toggleSelected(createGiphyMediaViewModel())
+        viewModel.toggleSelected(createGifMediaViewModel())
 
         // Assert
         assertThat(viewModel.selectedMediaViewModelList.value).isNull()
@@ -316,7 +316,7 @@ class GifPickerViewModelTest {
         id = Random().nextInt()
     }
 
-    private fun createGiphyMediaViewModel() = MutableGifMediaViewModel(
+    private fun createGifMediaViewModel() = MutableGifMediaViewModel(
             id = UUID.randomUUID().toString(),
             thumbnailUri = mock(),
             largeImageUri = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GiphyPickerDataSourceFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/GiphyPickerDataSourceFixtures.kt
@@ -1,9 +1,9 @@
-package org.wordpress.android.viewmodel.giphy
+package org.wordpress.android.viewmodel.gif
 
 import com.nhaarman.mockitokotlin2.mock
 
 object GiphyPickerDataSourceFixtures {
-    internal val expectedGifMediaViewModelCollection: List<GiphyMediaViewModel> = listOf(
+    internal val expectedGifMediaViewModelCollection: List<GifMediaViewModel> = listOf(
             mock(),
             mock(),
             mock(),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/provider/TenorProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/provider/TenorProviderTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy.provider
+package org.wordpress.android.viewmodel.gif.provider
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
@@ -25,9 +25,9 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.TestApplication
-import org.wordpress.android.viewmodel.giphy.provider.GifProvider.GifRequestFailedException
-import org.wordpress.android.viewmodel.giphy.provider.TenorProviderTestFixtures.expectedGifMediaViewModelCollection
-import org.wordpress.android.viewmodel.giphy.provider.TenorProviderTestFixtures.mockedTenorResult
+import org.wordpress.android.viewmodel.gif.provider.GifProvider.GifRequestFailedException
+import org.wordpress.android.viewmodel.gif.provider.TenorProviderTestFixtures.expectedGifMediaViewModelCollection
+import org.wordpress.android.viewmodel.gif.provider.TenorProviderTestFixtures.mockedTenorResult
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/provider/TenorProviderTestFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/gif/provider/TenorProviderTestFixtures.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.viewmodel.giphy.provider
+package org.wordpress.android.viewmodel.gif.provider
 
 import android.net.Uri
 import com.nhaarman.mockitokotlin2.mock
@@ -7,7 +7,7 @@ import com.tenor.android.core.constant.MediaCollectionFormat
 import com.tenor.android.core.model.impl.Media
 import com.tenor.android.core.model.impl.MediaCollection
 import com.tenor.android.core.model.impl.Result
-import org.wordpress.android.viewmodel.giphy.MutableGiphyMediaViewModel
+import org.wordpress.android.viewmodel.gif.MutableGifMediaViewModel
 
 object TenorProviderTestFixtures {
     internal val mockedTenorResult
@@ -48,7 +48,7 @@ object TenorProviderTestFixtures {
             mock<Media>().apply { whenever(this.url).thenReturn(mockContent) }
 
     private fun createExpectedGifMediaViewModel(expectedContent: String) =
-            MutableGiphyMediaViewModel(
+            MutableGifMediaViewModel(
                     expectedContent,
                     Uri.parse("$expectedContent gif_nano"),
                     Uri.parse("$expectedContent gif_tiny"),


### PR DESCRIPTION
Summary
------------
This Pull Request brings renaming for all Giphy references inside package, classes, documentation and UI strings. Giving sequence to the [issue 11456](https://github.com/wordpress-mobile/WordPress-Android/issues/11456).

Here's the change log:

* Every UI string with `Giphy` information was replaced with `Tenor`. 

* The `giphy` packages inside `ui` and `viewmodel` were both renamed to only `gif`.

* All classes with the `Giphy` naming convention were renamed to only `Gif` to better fit the agnostic gif provider implementation strategy.

* All comments and documentation with references to `Giphy` or the Giphy SDK were readapted to better fit the `GifProvider` structure.

* Removed the Giphy SDK  reference at maven repository in `build.gradle`

Testing
------------

### Before testing ###
1. Create a Tenor API key and paste it associated with the `wp.tenor.api_key` as the value inside your `gradle.properties`
2. When testing verify that all UI strings correctly reference Tenor as the gif provider.

### Testing from the Post Editor ###
1. Click to create a new post
2. Click on the overflow button at the top right end of the screen
3. select the `Switch to classic editor` 
4. Click on the plus (+) button at the bottom left end of the screen
5. Select the `Choose from Tenor` option
6. Type in the search bar to query GIFs
7. Once inside the Gif Picker, make sure that `selection`, `preview` and `add` are all working as expected

### Testing from the Media Browser ###
1. Go to the Media Browser
2. Click on the Add button at the top right. Select the `Choose from Tenor` option
3. Type in the search bar to query GIFs
4. Once inside the Gif Picker, make sure that `selection`, `preview` and `add` are all working as expected


PR submission checklist
------------
- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
