### PR TITLE
Add Tenor feature flag through selected build type

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -66,7 +66,7 @@ android {
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
-        buildConfigField "boolean", "TENOR_AVAILABLE", "false"
+        buildConfigField "boolean", "TENOR_AVAILABLE", "true"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -87,6 +87,7 @@ android {
             }
             versionCode 837
             buildConfigField "boolean", "ME_ACTIVITY_AVAILABLE", "false"
+            buildConfigField "boolean", "TENOR_AVAILABLE", "false"
         }
 
         zalpha { // alpha version - enable experimental features
@@ -98,7 +99,6 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
-            buildConfigField "boolean", "TENOR_AVAILABLE", "true"
         }
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -66,6 +66,7 @@ android {
         testInstrumentationRunner 'org.wordpress.android.WordPressTestRunner'
 
         buildConfigField "boolean", "OFFER_GUTENBERG", "true"
+        buildConfigField "boolean", "TENOR_AVAILABLE", "false"
     }
 
     // Gutenberg's dependency - react-native-video is using
@@ -97,6 +98,7 @@ android {
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             dimension "buildType"
+            buildConfigField "boolean", "TENOR_AVAILABLE", "true"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -926,7 +926,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     });
         }
 
-        if (mBrowserType.isBrowser()) {
+        if (mBrowserType.isBrowser() && BuildConfig.TENOR_AVAILABLE) {
             popup.getMenu().add(R.string.photo_picker_gif).setOnMenuItemClickListener(
                     item -> {
                         doAddMediaItemClicked(AddMenuItem.ITEM_CHOOSE_GIF);

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -24,6 +24,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -301,11 +302,13 @@ public class PhotoPickerFragment extends Fragment {
                 }
             });
 
-            MenuItem itemGif = popup.getMenu().add(R.string.photo_picker_gif);
-            itemGif.setOnMenuItemClickListener(item -> {
-                doIconClicked(PhotoPickerIcon.GIF);
-                return true;
-            });
+            if (BuildConfig.TENOR_AVAILABLE) {
+                MenuItem itemGif = popup.getMenu().add(R.string.photo_picker_gif);
+                itemGif.setOnMenuItemClickListener(item -> {
+                    doIconClicked(PhotoPickerIcon.GIF);
+                    return true;
+                });
+            }
         }
 
         popup.show();


### PR DESCRIPTION
Summary
------------
This Pull Request makes possible to enable or disable the Tenor GIF picker availability accordingly to the selected WordPress build type. This change adds to the [issue 11456](https://github.com/wordpress-mobile/WordPress-Android/issues/11456).

| Wasabi and Zalpha  | Vanilla |
| ------------- | ------------- |
| ![screenshot-1585788487864](https://user-images.githubusercontent.com/5920403/78199760-f983c180-7462-11ea-8ddf-aab5daf67ef5.jpg)  | ![screenshot-1585788395658](https://user-images.githubusercontent.com/5920403/78199769-fe487580-7462-11ea-9c50-6f8ee8bfbfa7.jpg) |
| ![screenshot-1585788446924](https://user-images.githubusercontent.com/5920403/78199765-fd174880-7462-11ea-9f4d-d8e95d6b0afa.jpg)  | ![screenshot-1585788432154](https://user-images.githubusercontent.com/5920403/78199766-fdafdf00-7462-11ea-8dd8-b1b00994d0df.jpg)  |

The solution proposes the following implementation:

* The `BuildConfig` now receive the declaration of the boolean `TENOR_AVAILABLE` field directly from the `build.gradle`.

* The button availability to select the Tenor GIF picker follows the `TENOR_AVAILABLE` value, if the value is false, the button doesn't get configured and should never appear on the screen.

* The `TENOR_AVAILABLE` is set as `true` for the Wasabi and Zalpha builds and `false` for the Vanilla build.

Testing from the Post Editor
------------

### with Wasabi and Zalpha build ###
1. Click to create a new post
2. Click on the overflow button at the top right end of the screen
3. select the `Switch to classic editor` 
4. Click on the plus (+) button at the bottom left end of the screen
5. Verify that the `Choose from Tenor` option is available
6. Type in the search bar to query GIFs
7. Once inside the Gif Picker, make sure that `selection`, `preview` and `add` are all working as expected

### with Vanilla build ###
1. Click to create a new post
2. Click on the overflow button at the top right end of the screen
3. select the `Switch to classic editor` 
4. Click on the plus (+) button at the bottom left end of the screen
5. Verify that the `Choose from Tenor` option isn't there

Testing from the Media Browser
------------

### with Wasabi and Zalpha build ###
1. Go to the Media Browser
2. Click on the Add button at the top right
3. Verify that the `Choose from Tenor` option is available
4. Type in the search bar to query GIFs
5. Once inside the Gif Picker, make sure that `selection`, `preview` and `add` are all working as expected

### with Vanilla build ###
1. Go to the Media Browser
2. Click on the Add button at the top right.
3. Verify that the `Choose from Tenor` option isn't there

PR submission checklist
------------
- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.